### PR TITLE
Feature: add handcards interfaces to operate player hand cards

### DIFF
--- a/webapp/packages/game/src/handCards.test.ts
+++ b/webapp/packages/game/src/handCards.test.ts
@@ -1,0 +1,28 @@
+import { HandCards } from './handCards';
+
+describe('handCard', () => {
+  describe('Add', () => {
+    it('should merge new card into hand cards', () => {
+      const handCards = ['knight', 'king', 'bishop'];
+      const newCards = ['queen', 'pawn', 'bishop'];
+      HandCards.Add(handCards, newCards);
+      expect(handCards).toEqual(['knight', 'king', 'bishop', 'queen', 'pawn', 'bishop']);
+    });
+  });
+
+  describe('Remove', () => {
+    it('should remove discard card from hand cards', () => {
+      const handCards = ['knight', 'pawn', 'king', 'bishop', 'queen', 'pawn', 'bishop', 'pawn'];
+      const discardCards = ['pawn', 'pawn', 'bishop'];
+      HandCards.Remove(handCards, discardCards);
+      expect(handCards).toEqual(['knight', 'king', 'queen', 'bishop', 'pawn']);
+    });
+
+    it('should not remove invalid discard from hand cards', () => {
+      const handCards = ['knight', 'pawn', 'king', 'bishop', 'queen', 'pawn', 'bishop', 'pawn'];
+      const discardCards = ['invalid_item'];
+      HandCards.Remove(handCards, discardCards);
+      expect(handCards).toEqual(['knight', 'pawn', 'king', 'bishop', 'queen', 'pawn', 'bishop', 'pawn']);
+    });
+  });
+});

--- a/webapp/packages/game/src/handCards.ts
+++ b/webapp/packages/game/src/handCards.ts
@@ -1,0 +1,39 @@
+export interface IHandCards {
+  Add<T>(handCards: T[], newCards: T[]): void;
+  Remove<T>(handCards: T[], discardCards: T[]): void;
+}
+
+function filterInplace<T>(array: T[], condition: (t: T, i: number, thisArg: T[]) => boolean) {
+  let write_ptr = 0;
+  let read_ptr = 0;
+  while (read_ptr < array.length) {
+    if (condition(array[read_ptr], read_ptr, array)) {
+      array[write_ptr] = array[read_ptr];
+      write_ptr++;
+    }
+    read_ptr++;
+  }
+  array.length = write_ptr;
+}
+
+export const HandCards: IHandCards = {
+  Add<T>(handCards: T[], newCards: T[]): void {
+    handCards.push(...newCards);
+  },
+  Remove<T>(handCards: T[], discardCards: T[]): void {
+    // O(M+N)
+    // convert discard cards to card => number map
+    const discardCardsMap = new Map<T, number>();
+    for (let discardCard of discardCards) {
+      discardCardsMap.set(discardCard, (discardCardsMap.get(discardCard) ?? 0) + 1);
+    }
+    // remove discard card as empty in hand cards
+    filterInplace(handCards, (handCard) => {
+      if ((discardCardsMap.get(handCard) ?? 0) > 0) {
+        discardCardsMap.set(handCard, discardCardsMap.get(handCard)! - 1);
+        return false;
+      }
+      return true;
+    });
+  },
+}

--- a/webapp/packages/game/src/index.ts
+++ b/webapp/packages/game/src/index.ts
@@ -1,5 +1,6 @@
 import { Game, PlayerID } from 'boardgame.io';
 import { Deck, CardDeck } from './deck';
+import { HandCards } from './handCards';
 import { OpenStarTerVillageType as type } from './types';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -50,13 +51,13 @@ export const OpenStarTerVillage: Game<type.State.Root> = {
         Deck.ShuffleDrawPile(state.decks.resources, shuffler);
 
         for (let playerId in state.players) {
-          const cards = Deck.Draw(state.decks.projects, 2);
-          state.players[playerId].hand.projects.push(...cards);
+          const projectCards = Deck.Draw(state.decks.projects, 2);
+          HandCards.Add(state.players[playerId].hand.projects, projectCards);
         }
 
         for (let playerId in state.players) {
-          const cards = Deck.Draw(state.decks.resources, 5);
-          state.players[playerId].hand.resources.push(...cards);
+          const resourceCards = Deck.Draw(state.decks.resources, 5);
+          HandCards.Add(state.players[playerId].hand.resources, resourceCards);
         }
 
         for (let playerId in state.players) {

--- a/webapp/packages/game/src/types.d.ts
+++ b/webapp/packages/game/src/types.d.ts
@@ -3,7 +3,7 @@ import { PlayerID } from 'boardgame.io';
 export declare namespace OpenStarTerVillageType {
   export declare namespace Card {
     export type Project = string;
-    export type Resource = string;
+    export type Resource = Job | Force;
     export type Job = string;
     export type Force = string;
     export type Event = string;


### PR DESCRIPTION
Some variable renaming based on #4 

Add handcards interfaces

Proposal:
```
export interface IHandCards {
  Add<T>(handCards: T[], newCards: T[]): void;
  Remove<T>(handCards: T[], discardCards: T[]): void;
}
```

Usage:
```
handCards.Add(state.hand.projects, newProjectCards)
handCards.Remove(state.hand.resources, discardProjectCards);
```