### PR TITLE
Feature: add move in buttons in client side

### DIFF
--- a/webapp/client/src/BoardGame.tsx
+++ b/webapp/client/src/BoardGame.tsx
@@ -2,23 +2,10 @@ import { OpenStarTerVillage } from '@open-star-ter-village/webapp-game';
 import { Client, BoardProps } from 'boardgame.io/react';
 import { Local } from 'boardgame.io/multiplayer';
 import { OpenStarTerVillageType } from 'packages/game/src/types';
+import Players from './Players/Players';
 
-const Board: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = ({ G, playerID }) => {
-  // show players summary
-  const Players = Object.keys(G.players).map(player => (
-    <div className='player' key={player}>
-      <div>Player {player}</div>
-      <ul>
-        <li>
-          WorkerTokens: {G.players[player].token.workers}
-        </li>
-        <li>
-          CompletedProjects: {G.players[player].completed.projects}
-        </li>
-      </ul>
-    </div>
-  ));
-
+const Board: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
+  const { G, playerID } = props;
   // show current player if not observer
   const CurrentPlayer = playerID !== null ? (
     <div>
@@ -37,7 +24,7 @@ const Board: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = ({ G, pla
 
   return (
     <div className='board'>
-      {Players}
+      <Players {...props} />
       {CurrentPlayer}
       {Table}
     </div>

--- a/webapp/client/src/BoardGame.tsx
+++ b/webapp/client/src/BoardGame.tsx
@@ -3,17 +3,10 @@ import { Client, BoardProps } from 'boardgame.io/react';
 import { Local } from 'boardgame.io/multiplayer';
 import { OpenStarTerVillageType } from 'packages/game/src/types';
 import Players from './Players/Players';
+import CurrentPlayer from './CurrentPlayer/CurrentPlayer';
 
 const Board: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
-  const { G, playerID } = props;
-  // show current player if not observer
-  const CurrentPlayer = playerID !== null ? (
-    <div>
-      <div>I am Player {playerID}</div>
-      Hand: {JSON.stringify(G.players[playerID].hand)}
-    </div>
-  ) : null;
-
+  const { G } = props;
   // show game table
   const Table = (
     <div>
@@ -25,7 +18,7 @@ const Board: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) =
   return (
     <div className='board'>
       <Players {...props} />
-      {CurrentPlayer}
+      <CurrentPlayer {...props} />
       {Table}
     </div>
   );

--- a/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
+++ b/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
@@ -1,0 +1,17 @@
+import { BoardProps } from 'boardgame.io/react';
+import { OpenStarTerVillageType } from 'packages/game/src/types';
+
+const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
+  const { G, playerID } = props;
+  if (playerID === null) {
+    return null;
+  }
+  return (
+    <div>
+      <div>I am Player {playerID}</div>
+      Hand: {JSON.stringify(G.players[playerID].hand)}
+    </div>
+  );
+}
+
+export default CurrentPlayer;

--- a/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
+++ b/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
@@ -9,7 +9,29 @@ const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (
   return (
     <div>
       <div>I am Player {playerID}</div>
-      Hand: {JSON.stringify(G.players[playerID].hand)}
+      <div>
+        Project Cards:
+        <ul>
+          {
+            G.players[playerID].hand.projects.map(p => (
+              <li>
+                <span>title: {p.name}</span>
+                <span>jobs: {JSON.stringify(p.jobs)}</span>
+              </li>))
+          }
+        </ul>
+      </div>
+      <div>
+        Resource Cards:
+        <ul>
+          {
+            G.players[playerID].hand.resources.map(r => (
+              <li>
+                <span>{r.name}</span>
+              </li>))
+          }
+        </ul>
+      </div>
     </div>
   );
 }

--- a/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
+++ b/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
@@ -2,13 +2,27 @@ import { BoardProps } from 'boardgame.io/react';
 import { OpenStarTerVillageType } from 'packages/game/src/types';
 
 const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
-  const { G, playerID } = props;
+  const { G, playerID, moves, events } = props;
   if (playerID === null) {
     return null;
   }
+  // TODO: replace indices with selected states
+  const projectCardIndex: number = 0;
+  const resourceCardIndex: number = 0;
+  const activeProjectIndex: number = 0;
+  const onCreateProject = () => moves.createProject(projectCardIndex, resourceCardIndex);
+  const onRecruit = () => moves.recruit(resourceCardIndex, activeProjectIndex);
+  const onEndAction = () => events.endStage!();
+  const onRefillAndEnd = () => moves.refillAndEnd();
   return (
     <div>
       <div>I am Player {playerID}</div>
+      <div>
+        <button onClick={onCreateProject}>Create Project</button>
+        <button onClick={onRecruit}>Recruit</button>
+        <button onClick={onEndAction}>End Action</button>
+        <button onClick={onRefillAndEnd}>Refill and End</button>
+      </div>
       <div>
         Project Cards:
         <ul>

--- a/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
+++ b/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
@@ -1,7 +1,7 @@
 import { BoardProps } from 'boardgame.io/react';
-import { OpenStarTerVillageType } from 'packages/game/src/types';
+import { OpenStarTerVillageType as Type } from 'packages/game/src/types';
 
-const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
+const CurrentPlayer: React.FC<BoardProps<Type.State.Root>> = (props) => {
   const { G, playerID, moves, events, ctx } = props;
   if (playerID === null) {
     return null;
@@ -10,8 +10,8 @@ const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (
   const projectCardIndex: number = 0;
   const resourceCardIndex: number = 0;
   const activeProjectIndex: number = 0;
-  const onCreateProject = () => moves.createProject(projectCardIndex, resourceCardIndex);
-  const onRecruit = () => moves.recruit(resourceCardIndex, activeProjectIndex);
+  const onCreateProject = () => (moves.createProject as Type.Move.CreateProject)(projectCardIndex, resourceCardIndex);
+  const onRecruit = () => (moves.recruit as Type.Move.Recruit)(resourceCardIndex, activeProjectIndex);
   const onEndAction = () => events.endStage!();
   const onRefillAndEnd = () => moves.refillAndEnd();
   const myCurrentStage = ctx.activePlayers ? ctx.activePlayers[playerID] : ''

--- a/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
+++ b/webapp/client/src/CurrentPlayer/CurrentPlayer.tsx
@@ -2,7 +2,7 @@ import { BoardProps } from 'boardgame.io/react';
 import { OpenStarTerVillageType } from 'packages/game/src/types';
 
 const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
-  const { G, playerID, moves, events } = props;
+  const { G, playerID, moves, events, ctx } = props;
   if (playerID === null) {
     return null;
   }
@@ -14,9 +14,11 @@ const CurrentPlayer: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (
   const onRecruit = () => moves.recruit(resourceCardIndex, activeProjectIndex);
   const onEndAction = () => events.endStage!();
   const onRefillAndEnd = () => moves.refillAndEnd();
+  const myCurrentStage = ctx.activePlayers ? ctx.activePlayers[playerID] : ''
   return (
     <div>
       <div>I am Player {playerID}</div>
+      {myCurrentStage ? <div>my current stage: {myCurrentStage}</div> : null}
       <div>
         <button onClick={onCreateProject}>Create Project</button>
         <button onClick={onRecruit}>Recruit</button>

--- a/webapp/client/src/Players/Players.tsx
+++ b/webapp/client/src/Players/Players.tsx
@@ -1,0 +1,25 @@
+import { BoardProps } from 'boardgame.io/react';
+import { OpenStarTerVillageType } from 'packages/game/src/types';
+
+const Players: React.FC<BoardProps<OpenStarTerVillageType.State.Root>> = (props) => {
+  const { G } = props;
+  const players = Object.keys(G.players).map(player => (
+    <div className='player' key={player}>
+      <div>Player {player}</div>
+      <ul>
+        <li>
+          WorkerTokens: {G.players[player].token.workers}
+        </li>
+        <li>
+          ActionTokens: {G.players[player].token.actions}
+        </li>
+        <li>
+          CompletedProjects: {G.players[player].completed.projects}
+        </li>
+      </ul>
+    </div>
+  ));
+  return (<>{players}</>);
+}
+
+export default Players;

--- a/webapp/packages/game/src/index.ts
+++ b/webapp/packages/game/src/index.ts
@@ -139,6 +139,7 @@ export const OpenStarTerVillage: Game<type.State.Root> = {
               slots[slotIndex] = 1;
               const contributions = { [resourceCard.name]: 1 };
               G.table.activeProjects.push({ card: projectCard, slots, contributions });
+              Deck.Discard(G.decks.resources, [resourceCard]);
             }
           },
           recruit: {

--- a/webapp/packages/game/src/types.d.ts
+++ b/webapp/packages/game/src/types.d.ts
@@ -59,4 +59,10 @@ export declare namespace OpenStarTerVillageType {
       contributions: Record<string, number>;
     }
   }
+
+  export declare namespace Move {
+    export type CreateProject = (projectCardIndex: number, resourceCardIndex: number) => void;
+    export type Recruit = (resourceCardIndex: number, activeProjectIndex: number) => void;
+    export type Contribute = (contributions: { activeProjectIndex: number; slotIndex: number; value: number }[]) => void;
+  }
 }


### PR DESCRIPTION
Based on #20 
Major:
Add following buttons in current player panel
1. create project
2. recruit
3. end action
4. refill and end turn

minor:
1. Add move function types and share across core, client and server sides.
2. bugfix: create project and recruit moves should act in server side rather than client side. Because decks are invisible in client.