### PR TITLE
feat(homepage): add netlify redirect rule to redirect en site

### DIFF
--- a/homepage/public/_redirects
+++ b/homepage/public/_redirects
@@ -1,4 +1,5 @@
 # Redirects from what the browser requests to what we serve
+/en/*                     https://openstartervillage-en.netlify.app/:splat  200
 
 # Abbreivations redirect
 /s/manual                       https://drive.google.com/file/d/1PQQfFv0QSdt3qymEEu5B_NrmKSsn34UI/view?usp=sharing


### PR DESCRIPTION
# Description

Please add the description of the changes here.

## BREAKING CHANGE

- `/en/*` redirect to English site `openstartervillage-en.netlify.app/*`

## Major

- major change items. If you don't have any major change items, please remove this section.

## minor

- minor change items. If you don't have any minor change items, please remove this section.

# Impaction

## Screenshots

Please attach screenshots of UI accordingly. If you don't have any UI changes, please remove this section.

### Before

Please attach screenshots of the before state.
If you don't have any screenshots, please write N/A here.

### After

Please attach screenshots of the after state.
If you don't have any screenshots, please write N/A here.

## Performance

If you have any performance data, please attach it here.

### Build and deploy time

#### Before

Please attach the build and deploy time of the before state.

#### After

Please attach the build and deploy time of the after state.

### LightHouse

#### Before

Please attach the LightHouse result of the before state.

#### After

Please attach the LightHouse result of the after state.
