### PR TITLE
fix(homepage): headline should not be covered by nav bar

### DIFF
--- a/homepage/public/css/style.css
+++ b/homepage/public/css/style.css
@@ -41,7 +41,7 @@ p {
   height: 100vh;
 }
 .headline {
-  height: 15vh;
+  height: 9rem;
   display: flex;
   justify-content: center;
   align-items: flex-end;


### PR DESCRIPTION
# Description

Headline should not be covered by nav bar.
replace vh w/ rem on headline height

## BREAKING CHANGE

N/A

## Major

- N/A

## minor

- update headline styling

# Impaction

## Screenshots

### Before

<img width="1840" alt="Screenshot 2023-07-13 at 00 31 17" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/412ec1de-0f64-4482-97da-ac4af5b9f96b">

### After

<img width="1840" alt="Screenshot 2023-07-13 at 00 26 52" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/43ddfd59-e146-4130-b8a2-7e3252adb88a">
 
## Performance

If you have any performance data, please attach it here.

### Build and deploy time

#### Before

Please attach the build and deploy time of the before state.

#### After

Please attach the build and deploy time of the after state.

N/A