### PR TITLE
feat(homepage): optimise images - part one - replace img tag w/ next/image

### DIFF
--- a/homepage/next.config.js
+++ b/homepage/next.config.js
@@ -3,7 +3,4 @@
  */
 module.exports = {
   swcMinify: true,
-  images: {
-    unoptimized: true,
-  },
 };

--- a/homepage/src/components/banner.jsx
+++ b/homepage/src/components/banner.jsx
@@ -1,8 +1,9 @@
+import Image from 'next/image';
 import Social from './social';
 
 const Banner = ({ heroImage, title, subtitle = '', highlights = [] }) => (
   <div className="banner">
-    <img src={heroImage} />
+    <Image src={heroImage} alt={`banner-${title}-${subtitle}`} />
     <div className="container">
       <div className="banner-details">
         <h1>{title}</h1>

--- a/homepage/src/components/banner.jsx
+++ b/homepage/src/components/banner.jsx
@@ -3,7 +3,7 @@ import Social from './social';
 
 const Banner = ({ heroImage, title, subtitle = '', highlights = [] }) => (
   <div className="banner">
-    <Image src={heroImage} alt={`banner-${title}-${subtitle}`} />
+    <Image src={heroImage} alt={`banner-${title}-${subtitle}`} sizes="100 vw" />
     <div className="container">
       <div className="banner-details">
         <h1>{title}</h1>

--- a/homepage/src/components/cardsColumns.jsx
+++ b/homepage/src/components/cardsColumns.jsx
@@ -29,7 +29,11 @@ const CardUnit = ({ card }) => (
     <div className="section-main">
       <h3>{card.frontMatter.title}</h3>
       <div>
-        <Image src={card.frontMatter.image} alt={card.frontMatter.title} />
+        <Image
+          src={card.frontMatter.image}
+          alt={card.frontMatter.title}
+          sizes="(max-width: 767px) 100vw, 33vw"
+        />
         <strong>{card.frontMatter.description}</strong>
         <div dangerouslySetInnerHTML={{ __html: card.content }} />
       </div>

--- a/homepage/src/components/cardsColumns.jsx
+++ b/homepage/src/components/cardsColumns.jsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 const CardsColumns = ({ id, title, cards, type }) => {
   // Group cards by type
   const groupCards = cards.filter((card) => card.frontMatter.type === type);
@@ -27,7 +29,7 @@ const CardUnit = ({ card }) => (
     <div className="section-main">
       <h3>{card.frontMatter.title}</h3>
       <div>
-        <img src={card.frontMatter.image} alt={card.frontMatter.title} />
+        <Image src={card.frontMatter.image} alt={card.frontMatter.title} />
         <strong>{card.frontMatter.description}</strong>
         <div dangerouslySetInnerHTML={{ __html: card.content }} />
       </div>

--- a/homepage/src/components/imageAndText.jsx
+++ b/homepage/src/components/imageAndText.jsx
@@ -5,7 +5,11 @@ const ImageAndText = ({ id, image, title, subtitle, content, highlights }) => (
     <div className="container">
       <div className="image-and-text-main row">
         <div className="left col-md-5 col-lg-4 mb-3">
-          <Image src={image} alt={`${title}-${subtitle}-image`} />
+          <Image
+            src={image}
+            alt={`${title}-${subtitle}-image`}
+            sizes="(max-width: 767px) 100vw, 33vw"
+          />
         </div>
         <div className="left col-md-7 col-lg-8">
           <div className="image-and-text-details">

--- a/homepage/src/components/imageAndText.jsx
+++ b/homepage/src/components/imageAndText.jsx
@@ -1,9 +1,11 @@
+import Image from 'next/image';
+
 const ImageAndText = ({ id, image, title, subtitle, content, highlights }) => (
   <div className="section" id={id}>
     <div className="container">
       <div className="image-and-text-main row">
         <div className="left col-md-5 col-lg-4 mb-3">
-          <img src={image} alt={`${title}-${subtitle}-image`} />
+          <Image src={image} alt={`${title}-${subtitle}-image`} />
         </div>
         <div className="left col-md-7 col-lg-8">
           <div className="image-and-text-details">

--- a/homepage/src/components/logo.jsx
+++ b/homepage/src/components/logo.jsx
@@ -1,7 +1,9 @@
+import Image from 'next/image';
+
 const Logo = ({ text, src }) => (
   <div className="flex flex-row flex-align-center">
     <span className="logo-title">{text}</span>
-    <img className="logo-image" src={src} />
+    <Image className="logo-image" src={src} alt={`${text}-logo`} />
   </div>
 );
 

--- a/homepage/src/components/logo.jsx
+++ b/homepage/src/components/logo.jsx
@@ -3,7 +3,12 @@ import Image from 'next/image';
 const Logo = ({ text, src }) => (
   <div className="flex flex-row flex-align-center">
     <span className="logo-title">{text}</span>
-    <Image className="logo-image" src={src} alt={`${text}-logo`} />
+    <Image
+      className="logo-image"
+      src={src}
+      alt={`${text}-logo`}
+      sizes="(max-width: 767px) 100vw, 50vw"
+    />
   </div>
 );
 

--- a/homepage/src/layouts/header.jsx
+++ b/homepage/src/layouts/header.jsx
@@ -8,7 +8,7 @@ const Header = ({ logo, nav }) => (
       <nav className="navbar navbar-expand-lg">
         <div className="logo navbar-brand">
           <Link href="/">
-            <Image src={logo} height="48" alt="logo" />
+            <Image src={logo} height="48" alt="logo" sizes="70px" />
           </Link>
         </div>
         <button

--- a/homepage/src/layouts/header.jsx
+++ b/homepage/src/layouts/header.jsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { siteData } from '../constants';
+import Image from 'next/image';
 
 const Header = ({ logo, nav }) => (
   <header className="site-header fixed-top">
@@ -7,7 +8,7 @@ const Header = ({ logo, nav }) => (
       <nav className="navbar navbar-expand-lg">
         <div className="logo navbar-brand">
           <Link href="/">
-            <img src={logo} height="48" alt="logo" />
+            <Image src={logo} height="48" alt="logo" />
           </Link>
         </div>
         <button


### PR DESCRIPTION
# Description

Replace img tag w/ next/image component

## BREAKING CHANGE

N/A

# Impaction

## Screenshots

- image can be optimised by nextjs runtime

## Performance

### Build and deploy time

#### Before

1m25s (w/ cached)

#### After

1m47s (w/ cached)

### LightHouse

#### Before

<img width="1395" alt="Screenshot 2023-07-16 at 18 00 16" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/eaf486f4-e2ec-4576-ac15-69f1fab2846e">

#### After

<img width="1392" alt="Screenshot 2023-07-22 at 16 16 06" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/97a0adf4-792d-4a92-aef9-af33691a62be">
