### PR TITLE
feat(homepage): add optional tag on card description cms config

### DIFF
--- a/homepage/public/admin/config.yml
+++ b/homepage/public/admin/config.yml
@@ -48,6 +48,7 @@ collections: # A list of collections the CMS should be able to edit
           label: 'Description',
           name: 'description',
           widget: 'string',
+          required: false,
           i18n: true,
         }
       - {


### PR DESCRIPTION
# Description

## minor

- card description is optional in CMS config

