### PR TITLE
feat: project card will be grouped by subtype tag

### DIFF
--- a/homepage/src/components/cardsGrid.jsx
+++ b/homepage/src/components/cardsGrid.jsx
@@ -1,16 +1,33 @@
-const CardsGrid = ({ id, title, cards, filter }) => {
+const CardsGrid = ({
+  id,
+  title,
+  cards,
+  filter,
+  projectCardSubtype = '',
+  projectCardSubtitle = '',
+}) => {
   // Group cards by type
   const groupCards = cards.filter((card) => card.frontMatter.type === filter);
   // Filter cards by draft
-  const filterGroupedCards = groupCards.filter(
-    (card) => !card.frontMatter.draft,
-  );
+  let filterGroupedCards = groupCards.filter((card) => !card.frontMatter.draft);
+  // Project cards grouped by subtype tag
+  if (projectCardSubtype) {
+    filterGroupedCards = filterGroupedCards.filter((card) =>
+      card.frontMatter.tags?.includes(projectCardSubtype),
+    );
+  }
 
   return (
     <div className="section" id={id}>
       <div className="container">
         <div className="section-head">
-          <h2>{title}</h2>
+          {projectCardSubtype ? (
+            <h2>
+              {title} | {projectCardSubtitle}
+            </h2>
+          ) : (
+            <h2>{title}</h2>
+          )}
         </div>
         <div className="row">
           {filterGroupedCards.map((card, index) => (

--- a/homepage/src/pages/cards.jsx
+++ b/homepage/src/pages/cards.jsx
@@ -61,6 +61,21 @@ export const getStaticProps = async ({ locale }) => {
     'zh-tw': '首頁',
   };
 
+  const projectCardSubtitle = {
+    'open gov': {
+      en: 'Open Government',
+      'zh-tw': '開放政府專案',
+    },
+    'open data': {
+      en: 'Open Data',
+      'zh-tw': '開放資料專案',
+    },
+    'open source': {
+      en: 'Open Source',
+      'zh-tw': '開放原始碼專案',
+    },
+  };
+
   const navigationList = [
     { link: `#page-top`, text: backToTop[locale] },
     { link: `#project-cards`, text: projectCardTitle[locale] },
@@ -88,6 +103,11 @@ export const getStaticProps = async ({ locale }) => {
       projectCardTitle: projectCardTitle[locale],
       jobCardTitle: jobCardTitle[locale],
       eventCardTitle: eventCardTitle[locale],
+      projectCardSubtitle: {
+        'open gov': projectCardSubtitle['open gov'][locale],
+        'open data': projectCardSubtitle['open data'][locale],
+        'open source': projectCardSubtitle['open source'][locale],
+      },
     },
   };
 };
@@ -99,6 +119,7 @@ const cards = ({
   projectCardTitle,
   jobCardTitle,
   eventCardTitle,
+  projectCardSubtitle,
 }) => {
   return (
     <>
@@ -112,6 +133,24 @@ const cards = ({
         title={projectCardTitle}
         cards={cards}
         filter={`project`}
+        projectCardSubtype={`open gov`}
+        projectCardSubtitle={projectCardSubtitle['open gov']}
+      />
+      <CardsGrid
+        id={`project-cards`}
+        title={projectCardTitle}
+        cards={cards}
+        filter={`project`}
+        projectCardSubtype={`open data`}
+        projectCardSubtitle={projectCardSubtitle['open data']}
+      />
+      <CardsGrid
+        id={`project-cards`}
+        title={projectCardTitle}
+        cards={cards}
+        filter={`project`}
+        projectCardSubtype={`open source`}
+        projectCardSubtitle={projectCardSubtitle['open source']}
       />
       <CardsGrid
         id={`job-cards`}


### PR DESCRIPTION
# Description

Add subtype filter to Project Card

## minor

- Project Card grouped by `open gov`, `open data` and `open source`

# Impaction

## Screenshot

| Before | After |
| ------ | ------ |
| <img width="1840" alt="Screenshot 2023-07-28 at 01 38 02" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/443d88e5-a902-409c-a405-97f0ed65ab02"> |  <img width="1840" alt="Screenshot 2023-07-28 at 01 37 45" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/d40c4c67-4f3e-4e9d-ad91-17ca7fa73d85"> |




