### PR TITLE
fix(homepage): prepend / on image url as a workaround

### DIFF
--- a/homepage/public/admin/config.yml
+++ b/homepage/public/admin/config.yml
@@ -6,7 +6,7 @@ site_url: https://openstartervillage.ocf.tw
 
 publish_mode: editorial_workflow
 media_folder: homepage/public/images/uploads
-public_folder: images/uploads
+public_folder: /images/uploads
 
 locale: zh-tw
 
@@ -62,11 +62,12 @@ collections: # A list of collections the CMS should be able to edit
           label: 'Type',
           name: 'type',
           widget: 'select',
-          options: [
-            { label: '專案', value: 'project' },
-            { label: '人力', value: 'job' },
-            { label: '事件', value: 'event' },
-          ],
+          options:
+            [
+              { label: '專案', value: 'project' },
+              { label: '人力', value: 'job' },
+              { label: '事件', value: 'event' },
+            ],
           i18n: duplicate,
         }
       - {
@@ -75,20 +76,21 @@ collections: # A list of collections the CMS should be able to edit
           widget: 'select',
           required: false,
           multiple: true,
-          options: [
-            { label: '開放政府', value: 'open gov' },
-            { label: '開放資料', value: 'open data' },
-            { label: '開放原始碼', value: 'open source' },
-            { label: '基礎', value: 'basic' },
-            { label: '進階', value: 'advance' },
-            { label: '工程師', value: 'engineer' },
-            { label: '美術設計', value: 'designer' },
-            { label: '文字工作者', value: 'writer' },
-            { label: '行銷公關', value: 'marketing' },
-            { label: '議題工作者', value: 'advocator' },
-            { label: '公務員', value: 'civil servants' },
-            { label: '法務人員', value: 'legal' },
-          ],
+          options:
+            [
+              { label: '開放政府', value: 'open gov' },
+              { label: '開放資料', value: 'open data' },
+              { label: '開放原始碼', value: 'open source' },
+              { label: '基礎', value: 'basic' },
+              { label: '進階', value: 'advance' },
+              { label: '工程師', value: 'engineer' },
+              { label: '美術設計', value: 'designer' },
+              { label: '文字工作者', value: 'writer' },
+              { label: '行銷公關', value: 'marketing' },
+              { label: '議題工作者', value: 'advocator' },
+              { label: '公務員', value: 'civil servants' },
+              { label: '法務人員', value: 'legal' },
+            ],
           i18n: duplicate,
         }
       - { label: 'Content', name: 'body', widget: 'markdown', i18n: true }

--- a/homepage/src/pages/cards.jsx
+++ b/homepage/src/pages/cards.jsx
@@ -17,11 +17,16 @@ export const getStaticProps = async ({ locale }) => {
       ? card.frontMatter.image.replace('/homepage/public', '')
       : '/images/uploads/初階專案卡封面-01.png';
 
+    // Workaround for image prefix path. Will be removed after image path is fixed in all cards.
+    const image = !updatedImage.startsWith('/')
+      ? `/${updatedImage}`
+      : updatedImage;
+
     return {
       ...card,
       frontMatter: {
         ...card.frontMatter,
-        image: updatedImage,
+        image,
       },
     };
   });


### PR DESCRIPTION
# Description

Add a workaround solution to prepend / in image url. Will remove it after all pending card pull requests are merged

## minor

- bugfix: image base_path should start with /

# Impaction

## Screenshots

| Scenarios  | Before | After |
| ---------- | ------ | ----- |
| en site | <img width="1840" alt="Screenshot 2023-07-28 at 02 05 39" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/381fcf6e-db94-4082-8656-357e22673c5e"> | <img width="1840" alt="Screenshot 2023-07-28 at 02 08 37" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/97332c70-cb25-4881-8ac7-f2a2823b8140"> |
| zh-tw site | <img width="1840" alt="Screenshot 2023-07-28 at 02 26 45" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/9374ca74-4728-4a60-a01a-92fa171ebb9b"> | <img width="1840" alt="Screenshot 2023-07-28 at 02 25 18" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/dcbcd76e-cfbd-485e-9ca9-a51427fa2aae"> |

