### PR TITLE
fix: remove card content of job card and event card

### DIFF
--- a/homepage/src/components/cardsGrid.jsx
+++ b/homepage/src/components/cardsGrid.jsx
@@ -16,6 +16,12 @@ const CardsGrid = ({
       card.frontMatter.tags?.includes(projectCardSubtype),
     );
   }
+  // temporarily remove card content of Job card and Event card
+  if (filter === 'job' || filter === 'event') {
+    filterGroupedCards.forEach((card) => {
+      card.content = '';
+    });
+  }
 
   return (
     <div className="section" id={id}>


### PR DESCRIPTION
# Description

Temporarily remove card content of Job card and Event card

## minor

- remove card content

# Impaction

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1440" alt="截圖 2023-07-28 15 06 55" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/8fe972bf-4c94-4ba3-906b-c696a0ddc998"> | <img width="1440" alt="截圖 2023-07-28 15 07 28" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/04c82f85-c841-45b1-804e-cb0320d0249d">|




