### PR TITLE
fix: cards ref link should under list

### DIFF
--- a/homepage/_cards/en/全民追公車.md
+++ b/homepage/_cards/en/全民追公車.md
@@ -11,5 +11,5 @@ tags:
 ---
 The prototype of this project is "Bus Tracker Taipei". With data from Taipei and New Taipei City governments and the Public Transport Data eXchange platform established by Taiwan’s Ministry of Transportation and Communications, this app allows users to see bus routes, bus arrival times, as well as the transfer information of airport bus, Taiwan High Speed Rail, Taiwan Railway, YouBike, and other means of public transport. This is one of the best examples of public uses of government open data since 2013.
 
-- [Download in Google Play](https://play.google.com/store/apps/details?id=nexti.android.bustaipei&hl=zh_TW&gl=US)\
+- [Download in Google Play](https://play.google.com/store/apps/details?id=nexti.android.bustaipei&hl=zh_TW&gl=US)
 - [Download in App Store](https://apps.apple.com/tw/app/%E5%8F%B0%E5%8C%97%E7%AD%89%E5%85%AC%E8%BB%8A-%E5%85%AC%E8%BB%8A%E8%B7%AF%E7%B7%9A-%E6%8D%B7%E9%81%8B-%E5%8F%B0%E9%90%B5%E5%8B%95%E6%85%8B%E6%9F%A5%E8%A9%A2/id511832182)

--- a/homepage/_cards/zh-tw/全民追公車.md
+++ b/homepage/_cards/zh-tw/全民追公車.md
@@ -9,5 +9,5 @@ tags:
 ---
 專案原型為「台北等公車」，此 app 資料來源為台北市政府交通局、新北市政府交通局及交通部 PTX 平臺，不僅能看到公車路線、到站時間，更包含機場客運、高鐵、臺鐵、公共自行車和大眾運輸轉乘資訊，是 2013 以來政府開放資料使民間加值運用的良好案例之一。
 
-- [安卓載點](https://play.google.com/store/apps/details?id=nexti.android.bustaipei&hl=zh_TW&gl=US)\
+- [安卓載點](https://play.google.com/store/apps/details?id=nexti.android.bustaipei&hl=zh_TW&gl=US)
 - [iOS 載點](https://apps.apple.com/tw/app/%E5%8F%B0%E5%8C%97%E7%AD%89%E5%85%AC%E8%BB%8A-%E5%85%AC%E8%BB%8A%E8%B7%AF%E7%B7%9A-%E6%8D%B7%E9%81%8B-%E5%8F%B0%E9%90%B5%E5%8B%95%E6%85%8B%E6%9F%A5%E8%A9%A2/id511832182)

--- a/homepage/public/css/style.css
+++ b/homepage/public/css/style.css
@@ -175,7 +175,6 @@ body {
   background: #fff;
 }
 .section-main {
-  text-align: center;
   box-shadow: 3px 3px 8px 2px #0000000a;
   padding: 30px 30px;
   transition: 0.5s all;
@@ -187,6 +186,17 @@ body {
 .section-main:hover {
   box-shadow: 3px 3px 8px 2px #0000002b;
   transition: 0.5s all;
+}
+.section-main > h1,h2,h3,h4,h5,h6 {
+  text-align: center;
+}
+.section-main ul {
+  padding: 0;
+  list-style-type: none;
+}
+.section-main ul li::before {
+  content: '🔗';
+  margin-right: 10px;
 }
 .flex-row {
   display: flex;

--- a/homepage/src/components/threeColumns.jsx
+++ b/homepage/src/components/threeColumns.jsx
@@ -9,6 +9,7 @@ const ThreeColumns = ({ id, title, columns }) => (
           <div className="section-main">
             <h3>{columns[0][0]}</h3>
             <div
+              className="flex flex-col"
               dangerouslySetInnerHTML={{
                 __html: columns[0][1],
               }}
@@ -19,6 +20,7 @@ const ThreeColumns = ({ id, title, columns }) => (
           <div className="section-main">
             <h3>{columns[1][0]}</h3>
             <div
+              className="flex flex-col"
               dangerouslySetInnerHTML={{
                 __html: columns[1][1],
               }}
@@ -29,6 +31,7 @@ const ThreeColumns = ({ id, title, columns }) => (
           <div className="section-main">
             <h3>{columns[2][0]}</h3>
             <div
+              className="flex flex-col"
               dangerouslySetInnerHTML={{
                 __html: columns[2][1],
               }}

--- a/homepage/src/components/twoColumns.jsx
+++ b/homepage/src/components/twoColumns.jsx
@@ -9,6 +9,7 @@ const TwoColumns = ({ id, title, columns }) => (
           <div className="section-main">
             <h3>{columns[0][0]}</h3>
             <div
+              className="flex flex-col"
               dangerouslySetInnerHTML={{
                 __html: columns[0][1],
               }}
@@ -19,6 +20,7 @@ const TwoColumns = ({ id, title, columns }) => (
           <div className="section-main">
             <h3>{columns[1][0]}</h3>
             <div
+              className="flex flex-col"
               dangerouslySetInnerHTML={{
                 __html: columns[1][1],
               }}


### PR DESCRIPTION
# Description

UI Styling update

## BREAKING CHANGE

## Major

- Content align on the left for better i18n support

## minor

- improve link in cards

# Impaction

## Screenshots

| Scenarios  | Before | After |
| ---------- | ------ | ----- |
| Landing Page | <img width="1840" alt="Screenshot 2023-07-28 at 14 45 11" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/3dfce95d-6637-4efb-9649-44603da57b4c"> |  <img width="1840" alt="Screenshot 2023-07-28 at 14 53 08" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/cb281b5f-76d2-4dc6-8adc-8142b2e47b46"> |
| Activity Page | <img width="1840" alt="Screenshot 2023-07-28 at 14 45 18" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/c4fd7b96-3a80-4ca4-a19d-8d0d2e23a600"> | <img width="1840" alt="Screenshot 2023-07-28 at 14 44 38" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/561138e8-bba2-4420-bcb9-54fa5fe61908"> |
| Card Page | <img width="1840" alt="Screenshot 2023-07-28 at 14 45 27" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/201818ed-f26e-41d1-855f-9bc3957c5631"> ﻿| <img width="1840" alt="Screenshot 2023-07-28 at 14 44 12" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/d671eca6-4b22-4340-88b1-b231f83a225b"> |
