### PR TITLE
fix(homepage): fix image and text header

### DIFF
--- a/homepage/public/css/style.css
+++ b/homepage/public/css/style.css
@@ -187,7 +187,7 @@ body {
   box-shadow: 3px 3px 8px 2px #0000002b;
   transition: 0.5s all;
 }
-.section-main > h1,h2,h3,h4,h5,h6 {
+.section-main h1,h2,h3,h4,h5,h6 {
   text-align: center;
 }
 .section-main ul {
@@ -265,7 +265,6 @@ body {
 }
 .image-and-text-details .sub-position {
   margin-bottom: 10px;
-  display: block;
 }
 .image-and-text-details .details {
   padding: 0;


### PR DESCRIPTION
# Description

Fix image and text header. Header should not align center.

## minor

- Header in image & text should align left not center

# Impaction

## Screenshots

Please attach screenshots of UI accordingly. If you don't have any UI changes, please remove this section.

| Scenarios  | Before | After |
| ---------- | ------ | ----- |
| Landing Page | <img width="1840" alt="image" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/9dd13aae-9aac-4e6f-b95a-1b1e67316670"> | <img width="1840" alt="image" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/ef54ff62-76c6-42e5-9f8c-9b4619ccab26"> |
