### PR TITLE
bump(homepage): upgrade netlify-cms from ^2.0.0 to decap

### DIFF
--- a/homepage/public/admin/index.html
+++ b/homepage/public/admin/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="https://decap-cms.netlify.app/cms.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Description

## BREAKING CHANGE

- Upgrade netlify-cms from 2.10.192 to decap beta

# Impaction

## Screenshots

Resolve typing issues in CMS admin page

## Performance

N/A
