### PR TITLE
feature: add preview in cms pages collection

### DIFF
--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -3,6 +3,29 @@ import Head from 'next/head';
 import Script from 'next/script';
 import config from './config.json';
 
+import Banner from '../../components/banner';
+
+const PagePreview = ({ entry }) => {
+  const layoutList = entry.getIn(['data', 'layout_list']);
+  const sections = layoutList?.map((layout) => {
+    const layoutType = layout.get('type')?.toString();
+    if (layoutType === 'layout_banner') {
+      return (
+        <Banner
+          key={layout.get('title')?.toString()}
+          heroImage={layout.get('hero_image')?.toString()}
+          title={layout.get('title')?.toString()}
+          subtitle={layout.get('subtitle')?.toString()}
+          highlights={layout.get('highlights')?.toArray()}
+        />
+      );
+    } else {
+      return <div key={layout.get('title')?.toString()}></div>;
+    }
+  });
+  return <div>{sections}</div>;
+};
+
 const CMS = dynamic(
   () =>
     import('decap-cms-app').then((cms) => {
@@ -20,6 +43,8 @@ const CMS = dynamic(
         'https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700',
       );
       cms.registerPreviewStyle('/css/style.css');
+
+      cms.registerPreviewTemplate('pages', PagePreview);
     }),
   { ssr: false, loading: () => <p>Loading...</p> },
 );

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -73,7 +73,7 @@ const PagePreview = ({ entry }) => {
             columns={columns}
           />
         );
-      } else if (columnSize === 3) {
+      } else if (columnSize >= 3) {
         const columns = layout
           .get('columns')
           ?.map((column) => {

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -5,6 +5,7 @@ import config from './config.json';
 
 import Banner from '../../components/banner';
 import ImageAndText from '../../components/imageAndText';
+import Headline from '../../components/headline';
 
 const PagePreview = ({ entry }) => {
   const layoutList = entry.getIn(['data', 'layout_list']);
@@ -30,6 +31,14 @@ const PagePreview = ({ entry }) => {
           subtitle={layout.get('subtitle')?.toString()}
           content={layout.get('text')?.toString()}
           highlights={layout.get('highlights')?.toArray()}
+        />
+      );
+    } else if (layoutType === 'layout_headline') {
+      return (
+        <Headline
+          key={layout.get('title')?.toString()}
+          title={layout.get('title')?.toString()}
+          subtitle={layout.get('subtitle')?.toString()}
         />
       );
     } else {

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -6,6 +6,9 @@ import config from './config.json';
 import Banner from '../../components/banner';
 import ImageAndText from '../../components/imageAndText';
 import Headline from '../../components/headline';
+import Section from '../../components/section';
+import TwoColumns from '../../components/twoColumns';
+import ThreeColumns from '../../components/threeColumns';
 
 const PagePreview = ({ entry }) => {
   const layoutList = entry.getIn(['data', 'layout_list']);
@@ -41,6 +44,55 @@ const PagePreview = ({ entry }) => {
           subtitle={layout.get('subtitle')?.toString()}
         />
       );
+    } else if (layoutType === 'layout_section') {
+      const columnSize = layout.get('columns')?.size ?? 0;
+      if (columnSize === 0 || columnSize === 1) {
+        return (
+          <Section
+            key={layout.get('title')?.toString()}
+            id={layout.get('title')?.toString()}
+            title={layout.get('title')?.toString()}
+            subtitle={layout.getIn(['columns', 0, 'title'])?.toString()}
+            content={layout.getIn(['columns', 0, 'text'])?.toString()}
+          />
+        );
+      } else if (columnSize === 2) {
+        const columns = layout
+          .get('columns')
+          ?.map((column) => {
+            return [
+              column.get('title')?.toString(),
+              column.get('text')?.toString(),
+            ];
+          })
+          .toArray();
+        return (
+          <TwoColumns
+            key={layout.get('title')?.toString()}
+            id={layout.get('title')?.toString()}
+            title={layout.get('title')?.toString()}
+            columns={columns}
+          />
+        );
+      } else if (columnSize === 3) {
+        const columns = layout
+          .get('columns')
+          ?.map((column) => {
+            return [
+              column.get('title')?.toString(),
+              column.get('text')?.toString(),
+            ];
+          })
+          .toArray();
+        return (
+          <ThreeColumns
+            key={layout.get('title')?.toString()}
+            id={layout.get('title')?.toString()}
+            title={layout.get('title')?.toString()}
+            columns={columns}
+          />
+        );
+      }
     } else {
       return <div key={layout.get('title')?.toString()}></div>;
     }

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -7,6 +7,19 @@ const CMS = dynamic(
   () =>
     import('decap-cms-app').then((cms) => {
       cms.init({ config });
+      cms.registerPreviewStyle(
+        'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css',
+      );
+      cms.registerPreviewStyle(
+        'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css',
+      );
+      cms.registerPreviewStyle(
+        'https://fonts.googleapis.com/css?family=Montserrat:400,700',
+      );
+      cms.registerPreviewStyle(
+        'https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700',
+      );
+      cms.registerPreviewStyle('/css/style.css');
     }),
   { ssr: false, loading: () => <p>Loading...</p> },
 );

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -41,7 +41,6 @@ const PagePreview = ({ entry }) => {
         <Headline
           key={layout.get('title')?.toString()}
           title={layout.get('title')?.toString()}
-          subtitle={layout.get('subtitle')?.toString()}
         />
       );
     } else if (layoutType === 'layout_section') {

--- a/homepage/src/pages/admin/index.jsx
+++ b/homepage/src/pages/admin/index.jsx
@@ -4,6 +4,7 @@ import Script from 'next/script';
 import config from './config.json';
 
 import Banner from '../../components/banner';
+import ImageAndText from '../../components/imageAndText';
 
 const PagePreview = ({ entry }) => {
   const layoutList = entry.getIn(['data', 'layout_list']);
@@ -16,6 +17,18 @@ const PagePreview = ({ entry }) => {
           heroImage={layout.get('hero_image')?.toString()}
           title={layout.get('title')?.toString()}
           subtitle={layout.get('subtitle')?.toString()}
+          highlights={layout.get('highlights')?.toArray()}
+        />
+      );
+    } else if (layoutType === 'layout_image_text') {
+      return (
+        <ImageAndText
+          key={layout.get('title')?.toString()}
+          id={layout.get('title')?.toString()}
+          image={layout.get('image')?.toString()}
+          title={layout.get('title')?.toString()}
+          subtitle={layout.get('subtitle')?.toString()}
+          content={layout.get('text')?.toString()}
           highlights={layout.get('highlights')?.toArray()}
         />
       );


### PR DESCRIPTION
# Description

Add pages preview in pages collection. The preview includes following basic components.
- Banner
- Headline
- Section
- TwoColumns
- ThreeColumns

## Major

- Add Pages collection preview in CMS admin page

# Impaction

## Screenshots

Please attach screenshots of UI accordingly. If you don't have any UI changes, please remove this section.

| Scenarios  | Before | After |
| ---------- | ------ | ----- |
| Admin page / Pages collection | <img width="1791" alt="Screenshot 2566-08-27 at 16 52 19" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/9cefdee8-95ef-443a-8e13-05264a710c49"> | <img width="1791" alt="Screenshot 2566-08-27 at 16 52 30" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/8f34ad5d-d7f4-4a33-991b-41cfbea1f75f"> <img width="1791" alt="Screenshot 2566-08-27 at 16 52 37" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/98fd0af6-a625-4279-b791-467fbd397d0e"> <img width="1791" alt="Screenshot 2566-08-27 at 16 52 39" src="https://github.com/ocftw/open-star-ter-village/assets/1487883/80d96235-94a7-411f-a631-febadaec27a3"> |

## Performance

### Build and deploy time

| item       | Before | After  |
| ---------- | ------ | ------ |
| w/ Cached  | 02m06s | 02m14s |

### LightHouse

N/A