### PR TITLE
feat(homepage): add google site verfication in homepage

### DIFF
--- a/homepage/.prettierignore
+++ b/homepage/.prettierignore
@@ -1,3 +1,6 @@
 _legacy
 
 _cards
+_data
+_footer
+_pages

--- a/homepage/public/robots.txt
+++ b/homepage/public/robots.txt
@@ -1,0 +1,9 @@
+//robots.txt
+
+# Block all crawlers for /admin
+User-agent: *
+Disallow: /admin
+
+# Allow all crawlers
+User-agent: *
+Allow: /

--- a/homepage/src/pages/_document.jsx
+++ b/homepage/src/pages/_document.jsx
@@ -1,8 +1,9 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import { GTM_ID } from '../lib/gtm';
 
 export default function Document({ locale }) {
   return (
-    <Html lang={locale}>
+    <Html>
       <Head>
         <meta charSet="utf-8" />
         <link
@@ -35,10 +36,25 @@ export default function Document({ locale }) {
           src="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/js/fontawesome.min.js"
           defer
         ></script>
+        {/* <!-- Google tag (gtag.js) --> */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer',${GTM_ID});`,
+          }}
+        />
       </Head>
       <body id="page-top">
         <Main />
         <NextScript />
+        <noscript
+          dangerouslySetInnerHTML={{
+            __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_ID}" height="0" width="0" style="display: none; visibility: hidden;" />`,
+          }}
+        />
       </body>
     </Html>
   );

--- a/homepage/src/pages/index.jsx
+++ b/homepage/src/pages/index.jsx
@@ -41,6 +41,7 @@ const Index = ({ headInfo, page }) => (
     <Head>
       <title>{headInfo.title}</title>
       <meta name="description" content={headInfo.description} />
+      <meta name="google-site-verification" content="NejiRhdBA-bewypiYDtrGnKJ09VSH6-15HsXUNKdrm4" />
     </Head>
     <Script
       id="netlify-identity-widget"


### PR DESCRIPTION
# Description

Add `robots.txt` in openstartervillage.ocf.tw/robots.txt

## Major

- Add robots.txt
- Add google tag manager container in static page

## minor

- Update google verification to verify google search console

# Impaction

## Screenshots

No UI changes.

## Performance

### Build and deploy time

| item       | Before | After  |
| ---------- | ------ | ------ |
| w/ Cached  | 00m00s | 00m00s |
| w/o Cached | 00m00s | 00m00s |
