### PR TITLE
fix(homepage): remove unsupported syntax from robots.txt

### DIFF
--- a/homepage/public/robots.txt
+++ b/homepage/public/robots.txt
@@ -1,5 +1,3 @@
-//robots.txt
-
 # Block all crawlers for /admin
 User-agent: *
 Disallow: /admin

--- a/homepage/src/pages/_document.jsx
+++ b/homepage/src/pages/_document.jsx
@@ -43,7 +43,7 @@ export default function Document({ locale }) {
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer',${GTM_ID});`,
+            })(window,document,'script','dataLayer','${GTM_ID}');`,
           }}
         />
       </Head>


### PR DESCRIPTION
# Description

fix robots.txt and gtm script which led the SEO and Best Practice mark went down

## minor

- remove unsupport syntax from robots.txt
- fix gtm script

# Impaction

## Screenshots

N/A

## Performance

### Build and deploy time

| item       | Before | After  |
| ---------- | ------ | ------ |
| w/ Cached  | 00m00s | 00m00s |
| w/o Cached | 00m00s | 00m00s |
