### PR TITLE
fix: modify margin in logo component

### DIFF
--- a/homepage/public/css/style.css
+++ b/homepage/public/css/style.css
@@ -934,6 +934,9 @@ code {
 .logo-image {
   margin-left: 1rem;
 }
+.logo-margin {
+  margin: 0 15px;
+}
 @media only screen and (max-width: 991px) {
   .blogs-list .item {
     width: 50% !important;
@@ -975,6 +978,9 @@ code {
   }
   .logos {
     flex-wrap: wrap;
+  }
+  .logo-margin {
+    margin: 10px auto;
   }
 }
 @media only screen and (max-width: 568px) {

--- a/homepage/src/components/logo.jsx
+++ b/homepage/src/components/logo.jsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 
 const Logo = ({ text, src, dimension }) => (
-  <div className="flex flex-row flex-align-center">
+  <div className="flex flex-row flex-align-center logo-margin">
     <span className="logo-title">{text}</span>
     <Image
       className="logo-image"


### PR DESCRIPTION
# Description

Extend margin between OCF and FNF logos in footer. (issue #257)

## minor

- add margin in logo component.

# Impaction

## Screenshots

| Scenarios  | Before | After |
| ---------- | ------ | ----- |
| Desktop | <img width="541" alt="截圖 2023-10-18 00 07 38" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/41ac8e30-b73f-41e1-a6d5-ce443f759a61">  | <img width="606" alt="截圖 2023-10-18 01 18 48" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/b7795bd7-0c5e-4481-b2fe-789e19f349ef"> |
| Mobile | <img width="425" alt="截圖 2023-10-18 01 19 15" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/0a1bc349-b2f7-42cc-b99b-721bd390ec29"> | <img width="425" alt="截圖 2023-10-18 01 19 39" src="https://github.com/ocftw/open-star-ter-village/assets/62057991/23532333-6a31-4cad-a83b-3bf075cf501f"> |

