### PR TITLE
ci: upgrade actions/checkout and setup-node to v4, consolidate to Node 24.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/packages/webapp/src/game/utils.ts
+++ b/packages/webapp/src/game/utils.ts
@@ -27,3 +27,4 @@ export function filterInplace<T>(array: T[], condition: (t: T, i: number, thisAr
   }
   array.length = writePtr;
 }
+


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` and `actions/setup-node` from `v2` to `v4`
- Consolidates the Node.js matrix from `[18.x, 20.x]` to `[24.x]` (current LTS)

Fixes #343 — the `Cache service responded with 400` errors were caused by the deprecated Node.js 20 runtime used by `v2` actions. GitHub will enforce Node.js 24 for all actions starting June 2, 2026; Node 18 is already EOL.

## Test plan

- [ ] `Webapp CI` workflow runs on this PR without `Cache service responded with 400` errors
- [ ] Node 24.x job completes: checkout → setup-node → yarn install → webapp build

🤖 Generated with [Claude Code](https://claude.com/claude-code)