### PR TITLE
chore: establish spec-driven development workflow with RFCs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,14 +5,12 @@
       "Write(rfc/**)",
       "Edit(.claude/commands/**)",
       "Write(.claude/commands/**)",
-
       "Bash(gh pr comment:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr edit:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",
       "Bash(gh issue comment:*)",
-
       "Edit(packages/webapp/src/**)",
       "Write(packages/webapp/src/**)",
       "Edit(homepage/src/**)",
@@ -29,7 +27,6 @@
       "Bash(npx tsc:*)",
       "Bash(cd homepage && yarn lint)",
       "Bash(cd homepage && yarn build)",
-
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git status:*)",
@@ -46,5 +43,11 @@
       "Bash(git reset --hard:*)",
       "Bash(rm -rf:*)"
     ]
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true,
+    "codex@openai-codex": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "permissions": {
+    "allow": [
+      "Edit(rfc/**)",
+      "Write(rfc/**)",
+      "Edit(.claude/commands/**)",
+      "Write(.claude/commands/**)",
+
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue comment:*)",
+
+      "Edit(packages/webapp/src/**)",
+      "Write(packages/webapp/src/**)",
+      "Edit(homepage/src/**)",
+      "Write(homepage/src/**)",
+      "Edit(homepage/_cards/**)",
+      "Write(homepage/_cards/**)",
+      "Edit(homepage/_pages/**)",
+      "Write(homepage/_pages/**)",
+      "Edit(homepage/_footer/**)",
+      "Write(homepage/_footer/**)",
+      "Bash(yarn webapp build)",
+      "Bash(yarn webapp test)",
+      "Bash(yarn webapp lint)",
+      "Bash(npx tsc:*)",
+      "Bash(cd homepage && yarn lint)",
+      "Bash(cd homepage && yarn build)",
+
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git push origin:*)",
+      "Bash(git branch:*)"
+    ],
+    "deny": [
+      "Bash(git push origin main:*)",
+      "Bash(git push origin master:*)",
+      "Bash(git push --force origin main:*)",
+      "Bash(git push --force origin master:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(rm -rf:*)"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,254 +1,104 @@
-# Open StarTer Village - Development Agent Instructions
+# AGENTS.md — Executor Agent Instructions
 
-## Project Overview
+## Role
 
-**Open StarTer Village** is an open-source boardgame designed to help beginners understand open-source culture, project collaboration, and the benefits of open-source initiatives. The project consists of three main components:
+You are an **executor agent**. You receive a **task** from the Supervisor (Claude/Sonnet) and implement it end-to-end: write code, write tests, then report completion. You do not make architectural decisions — follow the task spec.
 
-1. **Physical Board Game** - The original tabletop game
-2. **Google Spreadsheet Prototype** - Early digital prototype using Google Apps Script
-3. **Web Application** - Modern web-based implementation using Next.js and boardgame.io
+## Scope hierarchy
 
-### Game Objectives
-- Teach open-source culture core values (open definitions, four freedoms)
-- Demonstrate open-source advantages and community organization
-- Show how to participate in collaborative open-source projects
-- Highlight important open-source, open-government, and open-data projects
+- **RFC** — large feature area authored by the Planner
+- **Plan** — one observable feature broken out of an RFC (e.g. "User can list public rooms")
+- **Task** — your unit of work: a single coding change within a plan
 
-### Game Specifications
-- **Players**: 3-6 players
-- **Duration**: ~60 minutes
-- **Languages**: Chinese (Traditional) and English
+## Before You Start
 
-## Repository Structure
+1. Read the relevant RFC in `rfc/` to understand the feature context
+2. Read any progress files in `rfc/NNN-progress/` for prior review findings
+3. Confirm your task scope — which project (`packages/webapp/` or `homepage/`), which domain, which files
+4. Stay within your assigned scope. Do not touch files outside your task unless the spec explicitly requires it.
+
+## Project Context
+
+This is a Yarn 3.4.1 monorepo with two active projects:
+
+- **`packages/webapp/`** — Next.js 14 + boardgame.io game app (TypeScript strict mode)
+  - Path alias: `@/*` maps to `packages/webapp/src/*`
+  - Two-process architecture: Next.js client (port 3000) + game server (port 3001)
+  - Two state systems: boardgame.io `GameState` (authoritative) + Redux (UI-only)
+
+- **`homepage/`** — Next.js 13 + Decap CMS marketing site
+  - Bilingual content: Traditional Chinese (`zh-Hant/`) and English (`en/`)
+  - Content in Markdown: `_cards/`, `_pages/`, `_footer/`
+
+## Implementation Rules
+
+- TypeScript strict mode — all new code must be strictly typed
+- Use `@/*` path alias for webapp imports (not relative paths)
+- Validate-before-mutate pattern in game moves: check preconditions, then apply state changes
+- No `console.log` in game logic — use structured error handling
+- Functional React components with hooks — no class components
+- One file per move in `src/game/moves/`
+- Pure state mutators in `src/game/store/slice/`
+
+## Commit Convention
 
 ```
-open-star-ter-village/
-├── google-spreadsheet/     # Google Apps Script prototype
-├── homepage/              # Official website (Next.js)
-├── packages/
-│   └── webapp/           # Main web application (Next.js + boardgame.io)
-├── package.json          # Root workspace configuration
-└── README.md            # Project documentation
+<type>(<scope>): <short description>
 ```
 
-## Technology Stack
+- **Types:** `feat`, `fix`, `refactor`, `test`, `chore`, `docs`, `style`, `perf`
+- Subject line under 72 characters
+- Imperative mood ("add" not "added")
+- One commit per small-scope change — do not batch unrelated changes
+- No body unless the change is non-obvious
 
-### Root Workspace
-- **Package Manager**: Yarn 3.4.1 with workspaces
-- **Node Version**: >=18
-- **Scripts**: Unified commands for all sub-projects
+## Post-Task Steps
 
-### Google Spreadsheet Prototype
-- **Language**: Google Apps Script (JavaScript)
-- **Tools**: @google/clasp for deployment
-- **Purpose**: Early prototype and testing
+After implementing your task, run these in order:
 
-### Homepage
-- **Framework**: Next.js 13.2.3
-- **Styling**: Custom CSS
-- **CMS**: Decap CMS for content management
-- **Content**: Markdown files with multilingual support (en/zh-Hant)
-
-### Web Application
-- **Frontend**: Next.js 14.2.3 + React 18
-- **Game Engine**: boardgame.io 0.50.2
-- **State Management**: Redux Toolkit + React Redux
-- **UI Framework**: Material-UI (MUI) 5.15.19
-- **Language**: TypeScript
-- **Architecture**: Client-server with real-time game state
-
-## Development Setup
-
-### Prerequisites
-- Node.js >=18
-- Yarn 3.4.1
-- Git
-
-### Initial Setup
+### 1. Validate
+**For webapp changes:**
 ```bash
-# Clone the repository
-git clone https://github.com/ocftw/open-star-ter-village.git
-cd open-star-ter-village
-
-# Install dependencies for all workspaces
-yarn install
-
-# Build all projects
-yarn all:build
+yarn webapp build        # must pass
+yarn webapp test         # must pass
+npx tsc --noEmit         # must pass
 ```
 
-### Development Commands
-
-#### All Projects
+**For homepage changes:**
 ```bash
-# Start development servers for all projects
-yarn all:dev
-
-# Build all projects
-yarn all:build
-
-# Start production servers
-yarn all:start
-
-# Lint all projects
-yarn all:lint
+cd homepage && yarn lint  # must pass
 ```
 
-#### Individual Projects
-```bash
-# Web Application
-yarn webapp dev          # Start development (Next.js + server)
-yarn webapp build        # Build for production
-yarn webapp start        # Start production server
-yarn webapp test         # Run tests
+### 2. Simplify
+Run `/simplify` to clean up redundant code before review.
 
-# Homepage
-cd homepage
-yarn dev                 # Start development server
-yarn build              # Build for production
-yarn start              # Start production server
-yarn lint               # Run linting
+### 3. Report completion
+Report back to the Supervisor with files changed, tests added, and validation results.
 
-# Google Spreadsheet
-cd google-spreadsheet
-yarn pull               # Pull from Google Apps Script
-yarn push               # Push to Google Apps Script
+## Code Review Mode (Supervisor-initiated)
+
+When the Supervisor runs a post-plan review, all three checks run in parallel:
+
+1. `/code-review:code-review` — Claude structural review
+2. `/codex:review` — Codex review
+3. `yarn webapp test` (or `cd homepage && yarn lint`) — automated tests
+
+Findings are structured as:
+
+```markdown
+### 🔴 Blockers (Critical)
+- `file/path.ts:42` — Description of the issue
+
+### 🟡 Warnings
+- `file/path.ts:78` — Description of the concern
+
+### 🔵 Nits
+- `file/path.ts:15` — Suggestion
 ```
 
-## Architecture Details
+Include `file:line` references for every finding. End with a verification section showing build/test/type-check results.
 
-### Web Application Architecture
-
-The web application uses a modern client-server architecture:
-
-#### Client Side (Next.js)
-- **Pages**: React components with TypeScript
-- **Components**: Modular UI components using MUI
-- **State Management**: Redux for global state, local state for UI
-- **Game Integration**: boardgame.io client for game state
-
-#### Server Side
-- **Game Server**: Custom server using boardgame.io
-- **Real-time Communication**: WebSocket connections
-- **Game Logic**: Pure TypeScript game engine
-
-#### Game Engine (boardgame.io)
-- **Game State**: Centralized state management
-- **Actions**: Player actions and game mechanics
-- **Stages**: Game flow control
-- **AI**: Optional AI players
-
-### Key Components
-
-#### Game Components
-- `BoardGame.tsx` - Main game container
-- `Table/` - Game board and project management
-- `ActionBoard/` - Player actions and controls
-- `UserPanel/` - Player hand and status
-
-#### Game Logic
-- `game/core/` - Core game mechanics
-- `game/data/` - Game data (cards, events, jobs)
-- `game/store/` - State management slices
-
-## Development Guidelines
-
-### Code Style
-- **TypeScript**: Strict typing for all new code
-- **ESLint**: Follow project linting rules
-- **Prettier**: Consistent code formatting
-- **Components**: Functional components with hooks
-
-### File Organization
-- **Components**: Grouped by feature/domain
-- **Types**: Shared types in dedicated files
-- **Utils**: Pure functions for utilities
-- **Constants**: Game constants and configuration
-
-### Testing Strategy
-- **Unit Tests**: Core game logic and utilities
-- **Integration Tests**: Component interactions
-- **E2E Tests**: Full game flow (future)
-
-### Internationalization
-- **Languages**: Chinese (Traditional) and English
-- **Content**: Markdown files in `_cards/` and `_pages/`
-- **UI**: Translation keys for interface elements
-
-## Contribution Workflow
-
-### Getting Started
-1. **Fork** the repository
-2. **Create** a feature branch
-3. **Set up** development environment
-4. **Make** your changes
-5. **Test** your changes
-6. **Submit** a pull request
-
-### Issue Guidelines
-- **Bug Reports**: Include steps to reproduce
-- **Feature Requests**: Describe use case and benefits
-- **Enhancements**: Link to existing discussions
-
-### Pull Request Guidelines
-- **Title**: Clear description of changes
-- **Description**: Explain what and why
-- **Tests**: Include relevant tests
-- **Documentation**: Update docs if needed
-
-## Game Development Focus Areas
-
-### Current Priorities
-1. **Core Game Mechanics**: Complete game rule implementation
-2. **UI/UX**: Improve player experience
-3. **Multiplayer**: Real-time game synchronization
-4. **Content**: Expand card library and scenarios
-
-### Future Enhancements
-1. **AI Players**: Computer-controlled opponents
-2. **Tournaments**: Competitive play features
-3. **Analytics**: Game statistics and insights
-4. **Mobile**: Responsive design improvements
-
-## Resources and Documentation
-
-### Official Links
-- **Website**: https://openstartervillage.ocf.tw/
-- **Discord**: https://discord.gg/JnTHGnxwYS
-- **Wiki**: https://github.com/ocftw/open-star-ter-village/wiki
-- **Issues**: https://github.com/ocftw/open-star-ter-village/issues
-
-### Game Resources
-- **Rules**: Google Drive folder with game rules
-- **Assets**: Visual materials and game components
-- **Educational Kit**: Teaching resources and guides
-
-### Technical Documentation
-- **boardgame.io**: https://boardgame.io/
-- **Next.js**: https://nextjs.org/docs
-- **Material-UI**: https://mui.com/
-- **Redux Toolkit**: https://redux-toolkit.js.org/
-
-## Troubleshooting
-
-### Common Issues
-1. **Node Version**: Ensure Node.js >=18
-2. **Yarn Version**: Use Yarn 3.4.1 (project-specific)
-3. **Port Conflicts**: Check for existing servers on ports 3000, 3001
-4. **Build Errors**: Clear node_modules and reinstall
-
-### Development Tips
-- Use `yarn webapp dev` for full development environment
-- Check browser console for client-side errors
-- Monitor server logs for backend issues
-- Use TypeScript strict mode for better code quality
-
-## License and Legal
-
-- **Game Content**: CC BY 4.0 License
-- **Code**: MIT License
-- **Contributions**: Must follow project license terms
-
----
-
-This AGENT.md provides comprehensive guidance for continuing development of the Open StarTer Village project. Follow these instructions to maintain consistency and quality across all components of this open-source boardgame initiative.
+**Auto-fix all critical issues.** Only escalate to a human when the blocker involves:
+- Architecture conflicts
+- Strategy gaps
+- Unclear scope requiring a decision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Game logic (moves, mutations) operates on `GameState` via boardgame.io; UI conce
 - **Yarn 3.4.1** — use project-local yarn, not system yarn
 - TypeScript strict mode is enabled; all new code must be strictly typed
 - Tests exist only for game core logic (`src/game/utils.test.ts`); component tests are not yet in place
-- CI runs `yarn run webapp build` on Node 18.x and 20.x on pushes/PRs to main
+- CI runs `yarn webapp build` on Node 18.x and 20.x on pushes/PRs to main
 
 ## Agent Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,38 @@ Game logic (moves, mutations) operates on `GameState` via boardgame.io; UI conce
 - TypeScript strict mode is enabled; all new code must be strictly typed
 - Tests exist only for game core logic (`src/game/utils.test.ts`); component tests are not yet in place
 - CI runs `yarn run webapp build` on Node 18.x and 20.x on pushes/PRs to main
+
+## Agent Workflow
+
+This project uses a multi-agent development workflow with three roles:
+
+- **Planner** (Claude / Opus 4.6): RFC writing, architecture decisions, plan breakdown
+- **Supervisor** (Claude / Sonnet 4.6): Plan oversight, review orchestration, merge requests
+- **Executor** (Codex plugin / gpt-5.4): Task implementation and testing
+
+### Process
+
+```
+RFC (Planner)
+  → Plans (Planner breaks RFC into observable features)
+    → Tasks (Supervisor breaks each plan into coding-agent units)
+      → Implement + Test in parallel (1–N Executor agents via Codex plugin)
+        → /simplify (post-task cleanup)
+          → Review + Test in parallel:
+              1. /code-review:code-review
+              2. /codex:review
+              3. yarn webapp test (or homepage lint)
+            → Auto-fix all critical issues
+              (escalate to human only for: architecture conflicts, strategy gaps, unclear scope)
+              → Commit → Push → Raise MR
+```
+
+### Scope hierarchy
+
+| Level | Owner | Description |
+|-------|-------|-------------|
+| **RFC** | Planner | Large feature area (e.g. "Create a game lobby") |
+| **Plan** | Planner → Supervisor | One observable feature (e.g. "User can list public rooms") |
+| **Task** | Supervisor → Executor | Single coding unit — implement + test, one agent handles end-to-end |
+
+See `rfc/002-agent-workflow-role-separation.md` for background.

--- a/rfc/001-rfc-infrastructure.md
+++ b/rfc/001-rfc-infrastructure.md
@@ -1,0 +1,112 @@
+# RFC 001: RFC Infrastructure
+
+**Status:** Draft
+**Author:** @ben196888
+**Created:** 2026-03-23
+**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346)
+
+## Description
+
+The project lacks a standardized process for proposing and tracking technical decisions. Specs have lived ad-hoc in various locations (or not at all), making it difficult to understand why decisions were made, what alternatives were considered, and what the implementation status is.
+
+This RFC bootstraps the RFC process itself: folder structure, naming conventions, template, lifecycle states, and progress tracking.
+
+## Goals
+
+- Establish `rfc/` as the canonical location for project RFCs
+- Define a consistent RFC template (Title, Description, Goals, Non-Goals, Solutions, Rejected Solutions, Testing Plan, SLAs)
+- Define lifecycle states for tracking RFC progress
+- Provide a `rfc/NNN-progress/` convention for review summaries and implementation notes
+- Migrate any existing specs into the new structure
+
+## Non-Goals
+
+- Enforcing RFC creation via CI checks or GitHub Actions
+- Retroactively writing RFCs for past features or decisions
+- Defining a formal governance process (voting, approval thresholds)
+
+## Solutions
+
+### 1. Folder Structure
+
+```
+rfc/
+├── TEMPLATE.md                             # Reusable RFC template
+├── 001-rfc-infrastructure.md               # This RFC
+├── 001-progress/                           # Progress tracking for RFC 001
+│   └── ...
+├── 002-agent-workflow-role-separation.md   # Agent workflow RFC
+├── 002-progress/                           # Progress tracking for RFC 002
+│   └── ...
+└── NNN-slug.md                             # Future RFCs
+```
+
+**Naming convention:** `NNN-kebab-case-slug.md` where NNN is a zero-padded sequential number.
+
+**Progress folders:** `NNN-progress/` contains review summaries, implementation notes, and other tracking artifacts. Files inside are freeform — no required structure.
+
+### 2. RFC Template
+
+See `rfc/TEMPLATE.md` for the full template. Every RFC must include:
+
+- **Metadata:** Status, Author, Created date, Related issues/PRs
+- **Description:** The problem and motivation
+- **Goals / Non-Goals:** Scope boundaries
+- **Solutions:** The proposed approach, in detail
+- **Rejected Solutions:** Alternatives considered and why they were rejected
+- **Testing Plan:** How to verify the solution
+- **SLAs:** Measurable targets where applicable
+
+### 3. Lifecycle States
+
+| State | Meaning | Who Transitions |
+|-------|---------|-----------------|
+| **Draft** | Initial proposal, open for feedback | Author |
+| **In Review** | Formally submitted for team review | Author |
+| **Accepted** | Approved for implementation | Maintainer |
+| **In Progress** | Implementation underway | Author / Executor |
+| **Complete** | Fully implemented and verified | Maintainer |
+
+Transitions are tracked by updating the `Status` field in the RFC frontmatter. There is no formal approval vote — maintainer judgment applies.
+
+### 4. Integration with Agent Workflow
+
+RFCs serve as the primary input for the Planner role (see RFC 002). The development process starts with an RFC:
+
+1. Planner drafts the RFC in `rfc/`
+2. RFC is reviewed and accepted
+3. Planner breaks the RFC into implementation tasks
+4. Executors implement; progress tracked in `rfc/NNN-progress/`
+5. RFC status updated to Complete when all tasks are done
+
+### 5. CLAUDE.md Reference
+
+Add a brief section to CLAUDE.md pointing agents to `rfc/` for feature specs and decision context.
+
+## Rejected Solutions
+
+### `docs/rfcs/` path
+Extra directory nesting. `rfc/` at the repo root is more discoverable and conventional across open-source projects.
+
+### Wiki-based RFCs
+GitHub Wiki pages are not version-controlled alongside code, making them easy to lose sync. RFCs in `rfc/` are reviewed in the same PR as the implementation.
+
+### GitHub Discussions as RFCs
+Discussions lack structured lifecycle tracking, cannot be co-located with code, and are harder to reference from agent workflows.
+
+### Notion / Google Docs
+External tools introduce access management overhead and are not version-controlled. Contributors need a GitHub account, not a Notion account.
+
+## Testing Plan
+
+1. **Template usability:** Verify `TEMPLATE.md` can be copied to create a new RFC with all required sections
+2. **Existing RFC conformance:** Verify RFC 002 (already committed) follows the template structure
+3. **Progress folder:** Create `rfc/001-progress/` and verify it can hold freeform tracking files
+4. **Agent discovery:** Verify that a Claude Code or Codex agent, given the instruction "read the relevant RFC", can find and parse RFCs in `rfc/`
+
+## SLAs
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| RFC review turnaround | ≤ 1 week from Draft → In Review decision | Maintainer acknowledges within 1 week |
+| RFC numbering | Sequential, no gaps | If an RFC is abandoned, its number is not reused |

--- a/rfc/002-agent-workflow-role-separation.md
+++ b/rfc/002-agent-workflow-role-separation.md
@@ -1,0 +1,233 @@
+# RFC 002: Agent Workflow & Role Separation
+
+**Status:** Draft
+**Author:** @ben196888
+**Created:** 2026-03-23
+**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [PR #335](https://github.com/ocftw/open-star-ter-village/pull/335)
+
+## Description
+
+During the development of PR #335 (`feature/align-game-rule-to-released-version`), we validated a multi-agent workflow using 3 Claude Code agents + 3 Codex agents running in parallel across game logic, architecture, and UI domains. This approach caught more issues than single-pass review and enabled deeper domain-specific analysis.
+
+However, the current process has friction:
+
+1. **No formalized roles** — Claude is used for both planning and execution, which is expensive when Codex can handle implementation at lower token cost.
+2. **Rigid agent structure** — the 3-domain pattern (game logic, architecture, UI) was validated for the webapp but doesn't generalize to the homepage project or smaller changes.
+3. **No reusable review process** — code review was done ad-hoc in PR comments rather than through a repeatable skill.
+
+This RFC formalizes agent roles, defines project-aware review strategies, and introduces a `/code-review:code-review` skill for self-service code review.
+
+## Goals
+
+- Define three distinct agent roles (Planner, Supervisor, Executor) with clear model assignments and responsibilities
+- Reduce Opus token usage by delegating implementation to Codex executors
+- Create a `/code-review:code-review` skill that adapts review strategy based on project type and change scope
+- Support the monorepo structure — different review strategies for webapp vs homepage
+- Enable maintainers and contributors to self-review PRs without consuming tokens via GitHub hooks
+
+## Non-Goals
+
+- Automating code review via GitHub Actions or webhooks (token cost risk from external triggers)
+- Mandating a fixed number of review agents per PR
+- Replacing human code review — this augments, not replaces, maintainer judgment
+- Defining permissions or settings.json configuration (covered separately)
+- Defining the RFC folder structure or template (covered by RFC 001)
+
+## Solutions
+
+### 1. Role Definitions
+
+Three roles with specific model assignments:
+
+| Role | Model | Responsibility | When Used |
+|------|-------|----------------|-----------|
+| **Planner** | Claude / Opus 4.6 | RFC writing, architecture decisions, plan mode, complex analysis | Starting new features, designing specs, breaking down large tasks |
+| **Supervisor** | Claude / Sonnet 4.6 | Code review, oversight, progress tracking, consolidation | PR reviews, mid-implementation checkpoints, quality gates |
+| **Executor** | Codex / gpt-5.4 | Code implementation, file edits, test writing, refactoring | Implementing planned tasks, writing tests, mechanical changes |
+
+**Role boundaries:**
+
+- **Planner** produces specs and plans; never writes production code directly. Uses plan mode to align with the user before handing off to executors.
+- **Supervisor** reviews executor output. Uses Sonnet for cost-efficient oversight and Codex for deeper domain-specific analysis. Consolidates findings from parallel review agents.
+- **Executor** receives scoped tasks from the Planner's output and implements them. Stays within the assigned scope (project and domain). Runs validation before reporting completion.
+
+All roles share the same commit conventions (Conventional Commits) and validation checklist.
+
+### 2. Project-Aware Review Strategy
+
+Instead of hardcoding 3 domain agents, the review strategy adapts to the project and change scope.
+
+**Webapp review domains:**
+
+| Domain | Scope | Files |
+|--------|-------|-------|
+| Game Logic | Moves, handlers, state mutations, rules, tests | `src/game/**` |
+| Architecture | Types, state management, build config, server, dependencies | `src/server.ts`, `src/lib/**`, `tsconfig*.json`, `package.json` |
+| UI | Components, props, hooks, accessibility, styles | `src/components/**`, `src/pages/**` |
+
+**Homepage review domains:**
+
+| Domain | Scope | Files |
+|--------|-------|-------|
+| Content & CMS | Card data, page content, footer, CMS config | `_cards/`, `_pages/`, `_footer/`, `src/CMS/` |
+| Components & Styling | Layouts, components, CSS, i18n | `src/components/`, `src/layouts/`, `public/css/` |
+
+**Scaling heuristic:**
+
+| Project | Default Agents | When to Scale Up |
+|---------|---------------|-----------------|
+| webapp | 1–3 depending on change scope | Large PRs touching multiple domains → up to 3 agents |
+| homepage | 1 (content + styling combined) | CMS schema changes or i18n overhaul → 2 agents |
+| cross-project | 1 per affected project | Monorepo config changes → add 1 infra agent |
+
+**Decision rule:** Count affected domains, not files. A 50-file change in one domain = 1 agent. A 10-file change across 3 domains = 3 agents.
+
+**No fixed agent cap.** Spawn as many executor agents as there are parallel tasks. For post-plan review, run all three review checks in parallel.
+
+### 3. Development Process
+
+```
+RFC (Planner / Opus)
+  → Plans: break RFC into observable features (Planner)
+    → Tasks: break each plan into coding-agent units (Supervisor)
+      → Implement + Test in parallel (1–N Executor / Codex agents)
+        → /simplify per task (post-task cleanup)
+          → Review + Test in parallel (post-plan):
+              1. /code-review:code-review
+              2. /codex:review
+              3. yarn webapp test (or homepage lint)
+            → Auto-fix all critical issues
+              (escalate only: architecture conflicts, strategy gaps, unclear scope)
+              → Commit → Push → Raise MR (Supervisor)
+```
+
+**Process notes:**
+
+- **RFC → Plans:** The Planner breaks a large RFC (e.g. "game lobby") into plans — each plan is one observable feature a Supervisor can verify end-to-end (e.g. "User can list public rooms").
+- **Plans → Tasks:** The Supervisor breaks each plan into tasks — the smallest coding unit an executor can complete independently: implement + test + validate.
+- **Parallel execution:** The Supervisor spawns 1–N Codex executor agents in parallel, one per task. No fixed cap — maximize parallelism across non-overlapping tasks.
+- **Post-task cleanup:** After each task, run `/simplify` to detect and remove redundant code before review.
+- **Post-plan review:** All three checks run in parallel — Claude review, Codex review, and automated tests.
+- **Auto-fix:** Executors fix all critical findings automatically. Human escalation only for architecture conflicts, strategy gaps, or unclear scope.
+
+### 4. Code Review Output Format
+
+All review agents (regardless of role or model) produce findings in this structure:
+
+```markdown
+## [Domain Name] Review
+
+### 🔴 Blockers (Critical)
+Must fix before merge.
+- `file/path.ts:42` — Description of the issue
+
+### 🟡 Warnings
+Should fix but won't break functionality.
+- `file/path.ts:78` — Description of the concern
+
+### 🔵 Nits
+Style, naming, minor improvements.
+- `file/path.ts:15` — Suggestion
+
+### ✅ Verification
+- [ ] `yarn webapp build` — pass/fail
+- [ ] `yarn webapp test` — pass/fail
+- [ ] `npx tsc --noEmit` — pass/fail
+```
+
+When multiple agents run in parallel, the Supervisor consolidates their findings into a single structured comment.
+
+### 5. `/code-review:code-review` Skill
+
+A Claude Code plugin skill that maintainers and contributors invoke manually. **Not attached to GitHub hooks or actions.**
+
+**Three invocation modes:**
+
+| Invocation | Behavior |
+|------------|----------|
+| `/code-review:code-review` | Review current branch vs base branch (git diff) |
+| `/code-review:code-review 335` | Review PR #335 by number (via `gh pr diff`) |
+| `/code-review:code-review https://github.com/.../pull/335` | Review PR by URL |
+
+**Skill behavior:**
+
+1. Determine the diff (from branch, PR number, or URL)
+2. Identify affected projects (webapp, homepage, or both)
+3. Map changed files to review domains
+4. Launch one agent per affected domain (soft cap: 3)
+5. Each agent reviews its domain and produces structured findings
+6. Consolidate into a single summary with verification results
+7. Post as PR comment (if PR exists) or output to console
+
+### 6. AGENTS.md Rewrite
+
+Replace the current generic `AGENTS.md` (254 lines, duplicates CLAUDE.md and README) with focused Codex executor instructions (~70 lines). See the updated `AGENTS.md` file for the full content.
+
+**What gets cut:** project overview, repo structure, tech stack, setup instructions, contribution workflow, troubleshooting, future enhancements, resource links — all already in CLAUDE.md or README.
+
+**What gets added:** role context, RFC awareness, domain scoping, commit conventions, validation checklist, code review output format.
+
+### 7. Permission Guidelines (Per-Role)
+
+Claude Code permissions (`.claude/settings.json`) cannot enforce role-based access — all agents share the same permission set. The table below documents the **intended** permissions per role as a guideline for contributors and future tooling.
+
+| Permission | Planner | Supervisor | Executor | Notes |
+|------------|:-------:|:----------:|:--------:|-------|
+| `Edit/Write(rfc/**)` | ✅ create | ✅ update | ❌ | Planner drafts RFCs; Supervisor updates progress |
+| `Edit/Write(.claude/commands/**)` | ✅ | ❌ | ❌ | Only Planner creates/updates skills |
+| `Edit/Write(packages/webapp/src/**)` | ❌ | ❌ | ✅ | Executor writes production code |
+| `Edit/Write(homepage/**)` | ❌ | ❌ | ✅ | Executor writes homepage code/content |
+| `gh pr create/edit` | ❌ | ✅ | ❌ | Supervisor manages PRs |
+| `gh pr comment` | ❌ | ✅ | ❌ | Supervisor posts review findings |
+| `gh pr view/diff` | ✅ | ✅ | ❌ | Read-only for Planner context |
+| `yarn build/test/lint`, `tsc` | ❌ | ✅ | ✅ | Validation commands |
+| `git add/commit` | ✅ | ✅ | ✅ | All roles can commit within scope |
+| `git push origin <branch>` | ✅ | ✅ | ✅ | Feature branches only |
+| `git push --force` | ❌ | ✅ | ✅ | Allowed on non-protected branches |
+| `git push origin main/master` | ❌ | ❌ | ❌ | **Always denied** |
+| `git reset --hard` | ❌ | ❌ | ❌ | **Always denied** |
+
+> **Current limitation:** These role boundaries are enforced by convention (AGENTS.md instructions, skill prompts), not by tooling. `.claude/settings.json` grants the union of all role permissions. Future work may explore per-agent permission scoping if Claude Code or Codex CLI adds support.
+
+## Rejected Solutions
+
+### Fixed 3-domain agent pattern
+The original issue proposed always using 3 agents (game logic, architecture, UI). Rejected because: (a) the homepage project doesn't have game logic, (b) small changes don't warrant 3 agents, (c) token cost scales linearly with agent count. The project-aware strategy with a soft cap is more flexible and cost-effective.
+
+### Single-agent review
+Using one agent for all review work. Rejected because: PR #335 demonstrated that parallel domain-scoped agents catch more issues than a single pass. The heuristic-based scaling preserves this benefit while avoiding unnecessary agent spawning for small changes.
+
+### GitHub Action–triggered review
+Attaching the review skill to a GitHub Action that triggers on PR events. Rejected because: any external actor can open a PR or issue, which would consume tokens uncontrollably. Manual invocation by maintainers/contributors keeps token spend intentional.
+
+### Claude-only workflow (no Codex)
+Using Claude for both planning and execution. Rejected because: Opus tokens are significantly more expensive than Codex/gpt-5.4 for implementation tasks. Delegating execution to Codex reduces cost while maintaining quality for mechanical coding work.
+
+## Testing Plan
+
+1. **Skill smoke test (webapp):** Create a test branch with webapp changes across multiple domains. Invoke `/code-review:code-review` and verify it:
+   - Correctly identifies affected webapp domains
+   - Launches the right number of agents (≤3)
+   - Produces structured output (Blockers/Warnings/Nits)
+   - Runs verification commands
+
+2. **Skill smoke test (homepage):** Create a test branch with homepage content changes. Invoke `/code-review:code-review` and verify it:
+   - Uses homepage-specific domain definitions
+   - Launches 1 agent (content + styling combined for small changes)
+
+3. **PR number invocation:** Run `/code-review:code-review 335` and verify it fetches the PR diff and reviews it correctly.
+
+4. **PR URL invocation:** Run `/code-review:code-review https://github.com/ocftw/open-star-ter-village/pull/335` and verify URL parsing works.
+
+5. **AGENTS.md validation:** Have a Codex executor agent read the new AGENTS.md and confirm it can extract: its role, the validation commands, commit convention, and review output format.
+
+6. **No regressions:** Run `yarn webapp build` and `yarn webapp test` to confirm doc-only changes don't break anything.
+
+## SLAs
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Review turnaround | < 10 minutes for typical PR | From `/code-review:code-review` invocation to consolidated output |
+| Executor agents | 1 per parallel task, no cap | Maximize parallelism across non-overlapping tasks |
+| Token budget guidance | Prefer Codex/gpt-5.4 for execution; reserve Opus for planning and complex analysis | No hard token limit; monitor and adjust |
+| Review coverage | All changed files reviewed by at least one domain agent | Uncategorized files default to the architecture domain |

--- a/rfc/002-agent-workflow-role-separation.md
+++ b/rfc/002-agent-workflow-role-separation.md
@@ -30,7 +30,7 @@ This RFC formalizes agent roles, defines project-aware review strategies, and in
 - Automating code review via GitHub Actions or webhooks (token cost risk from external triggers)
 - Mandating a fixed number of review agents per PR
 - Replacing human code review — this augments, not replaces, maintainer judgment
-- Defining permissions or settings.json configuration (covered separately)
+- Defining `.claude/settings.json` configuration (covered in RFC 003)
 - Defining the RFC folder structure or template (covered by RFC 001)
 
 ## Solutions
@@ -139,7 +139,7 @@ When multiple agents run in parallel, the Supervisor consolidates their findings
 
 ### 5. `/code-review:code-review` Skill
 
-A Claude Code plugin skill that maintainers and contributors invoke manually. **Not attached to GitHub hooks or actions.**
+A Claude Code plugin skill that maintainers and contributors invoke manually. **Not attached to GitHub hooks or actions.** This skill is a future deliverable of this RFC — it does not exist yet.
 
 **Three invocation modes:**
 
@@ -169,7 +169,7 @@ Replace the current generic `AGENTS.md` (254 lines, duplicates CLAUDE.md and REA
 
 ### 7. Permission Guidelines (Per-Role)
 
-Claude Code permissions (`.claude/settings.json`) cannot enforce role-based access — all agents share the same permission set. The table below documents the **intended** permissions per role as a guideline for contributors and future tooling.
+Claude Code permissions (`.claude/settings.json`) cannot enforce role-based access — all agents share the same permission set. The table below documents the **intended** permissions per role as a convention guideline. The actual `.claude/settings.json` configuration (union of all role permissions, deny list, settings file separation) is defined in [RFC 003](./003-permissions-hands-free-execution.md).
 
 | Permission | Planner | Supervisor | Executor | Notes |
 |------------|:-------:|:----------:|:--------:|-------|

--- a/rfc/003-permissions-hands-free-execution.md
+++ b/rfc/003-permissions-hands-free-execution.md
@@ -1,0 +1,133 @@
+# RFC 003: Permissions for Hands-Free Execution
+
+**Status:** Draft
+**Author:** @ben196888
+**Created:** 2026-03-23
+**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [RFC 002](./002-agent-workflow-role-separation.md)
+
+## Description
+
+During automated agent workflows (RFC 002), every file edit, git command, and agent spawn triggers an approval prompt in Claude Code. This friction breaks hands-free execution and forces human babysitting of routine operations.
+
+This RFC documents the permissions needed for each agent role to operate with minimal prompts, configures them in `.claude/settings.json`, and defines safety rails to prevent destructive operations.
+
+## Goals
+
+- Document all permissions needed by each role (Planner, Supervisor, Executor)
+- Configure `.claude/settings.json` with the union of role permissions (project-level, committable)
+- Define an explicit deny list for destructive operations on protected branches
+- Allow force push on non-protected (feature) branches
+- Provide a clear separation between project settings (shared) and local settings (personal)
+
+## Non-Goals
+
+- Per-role permission enforcement at the tooling level (not supported — see RFC 002, section 7)
+- GitHub branch protection rules (managed in GitHub repo settings, not in code)
+- Codex CLI permission configuration (Codex uses `--full-auto` mode with its own safety model)
+- CI/CD pipeline permissions (managed in GitHub Actions, not in Claude Code)
+
+## Solutions
+
+### 1. File Operation Permissions
+
+Scoped by project and purpose:
+
+| Permission | Role Intent | Reason |
+|------------|-------------|--------|
+| `Edit/Write(rfc/**)` | Planner, Supervisor | Create and update RFCs and progress files |
+| `Edit/Write(.claude/commands/**)` | Planner | Create and update skills |
+| `Edit/Write(packages/webapp/src/**)` | Executor | Webapp source code |
+| `Edit/Write(homepage/src/**)` | Executor | Homepage source code |
+| `Edit/Write(homepage/_cards/**)` | Executor | Homepage card content |
+| `Edit/Write(homepage/_pages/**)` | Executor | Homepage page content |
+| `Edit/Write(homepage/_footer/**)` | Executor | Homepage footer content |
+
+### 2. Shell Command Permissions
+
+#### Build & Validation
+| Permission | Role Intent | Reason |
+|------------|-------------|--------|
+| `yarn webapp build` | Supervisor, Executor | Build verification |
+| `yarn webapp test` | Supervisor, Executor | Test verification |
+| `yarn webapp lint` | Supervisor, Executor | Lint check |
+| `npx tsc:*` | Supervisor, Executor | Type checking |
+| `cd homepage && yarn lint` | Supervisor, Executor | Homepage lint |
+| `cd homepage && yarn build` | Supervisor, Executor | Homepage build |
+
+#### Git Operations
+| Permission | Role Intent | Reason |
+|------------|-------------|--------|
+| `git add:*` | All | Stage changes |
+| `git commit:*` | All | Create commits |
+| `git status:*` | All | Check working tree |
+| `git diff:*` | All | View changes |
+| `git log:*` | All | View history |
+| `git push origin:*` | All | Push feature branches |
+| `git branch:*` | All | Branch management |
+
+#### GitHub CLI
+| Permission | Role Intent | Reason |
+|------------|-------------|--------|
+| `gh pr comment:*` | Supervisor | Post review findings |
+| `gh pr create:*` | Supervisor | Create pull requests |
+| `gh pr edit:*` | Supervisor | Update PR metadata |
+| `gh pr view:*` | Planner, Supervisor | Read PR context |
+| `gh pr diff:*` | Planner, Supervisor | Read PR changes |
+| `gh issue comment:*` | Supervisor | Comment on issues |
+
+### 3. Deny List (Safety Rails)
+
+These operations are **always denied** regardless of role:
+
+| Denied Permission | Reason |
+|-------------------|--------|
+| `git push origin main:*` | Never push directly to main |
+| `git push origin master:*` | Never push directly to master |
+| `git push --force origin main:*` | Never force push to main |
+| `git push --force origin master:*` | Never force push to master |
+| `git reset --hard:*` | Destructive — loses uncommitted work |
+| `rm -rf:*` | Destructive — irreversible file deletion |
+
+**Note:** `git push --force` on feature branches is **allowed**. This enables interactive rebase workflows and fixup/squash commits on in-progress branches.
+
+### 4. Settings File Separation
+
+| File | Scope | Git | Contents |
+|------|-------|-----|----------|
+| `.claude/settings.json` | Project | Committed | Shared permissions (union of all roles) |
+| `.claude/settings.local.json` | Personal | Gitignored | User-specific overrides (MCP servers, personal tools) |
+
+Settings load in order: user → project → local. Later files override earlier ones. The project `settings.json` is the canonical reference for agent permissions.
+
+### 5. Current Configuration
+
+The current `.claude/settings.json` implements sections 1–3 above. See the file for the exact permission list.
+
+## Rejected Solutions
+
+### Per-agent permission files
+Claude Code does not support scoping permissions per agent or per role. All agents in a session share the same permission set from `settings.json`.
+
+### GitHub Action-based permission enforcement
+Adding a CI step to validate that agents didn't exceed their role permissions. Rejected because: adds CI complexity and token cost, and the enforcement happens after the fact rather than preventing the action.
+
+### Blanket `git push --force` deny
+The original issue proposed denying all force pushes. Rejected because: force push on feature branches is a legitimate workflow for interactive rebase and fixup commits. Only force push to protected branches (main/master) is denied.
+
+### `dontAsk` permission mode
+Setting `defaultMode: "dontAsk"` to skip all prompts. Rejected because: this bypasses ALL permission checks including the deny list, which is too permissive. Explicit allow/deny lists are safer.
+
+## Testing Plan
+
+1. **JSON validation:** Run `jq . .claude/settings.json` — must exit 0
+2. **Allow list verification:** In a Claude Code session, run an allowed command (e.g., `git status`) — should not prompt
+3. **Deny list verification:** Attempt `git push origin main` — should be blocked
+4. **Force push on feature branch:** Run `git push --force origin <feature-branch>` — should be allowed
+5. **File edit scope:** Edit a file in `packages/webapp/src/` — should not prompt. Edit a file outside allowed paths — should prompt.
+
+## SLAs
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Permission review | Within same PR as the feature using them | No standalone permission PRs without justification |
+| Deny list changes | Require maintainer approval | Safety-critical — cannot be self-approved |

--- a/rfc/004-llm-knowledge-base.md
+++ b/rfc/004-llm-knowledge-base.md
@@ -149,6 +149,8 @@ The LLM reads from all three raw sources and produces organized, interlinked art
 | `resources.md` | Drive links from all sources | All external resources with descriptions |
 | `homepage-editing.md` | wiki editing guide | CMS guide, block types, editorial workflow |
 
+**Language:** Wiki articles are written in English. Bilingual wiki content (zh-Hant translations) is deferred — at this scale, a Cursor skill or chat-based search interface on the website may serve multilingual users better than maintaining parallel article sets. This decision can be revisited when the wiki grows beyond ~15 articles.
+
 **Obsidian compatibility** (nice-to-have): Standard `[text](./path.md)` links work in both Obsidian and on the web. The `knowledge/` folder can be opened as an Obsidian vault directly without plugins.
 
 ### 4. Incremental Ingestion: `/add-file`
@@ -327,7 +329,7 @@ The article notes this is unnecessary at small scale. Auto-maintained index file
 Violates the explicit goal of keeping Drive files in place. Binary assets (PDFs, images, presentations) would bloat the repo. Cataloging with links and reading content via MCP is sufficient.
 
 ### Node.js / shell scripts for wiki tooling
-Python was chosen for `add_file.py` and `doctor.py` because it has stronger libraries for URL parsing, file type detection, and JSON processing. `buildSearchIndex.ts` is TypeScript because it lives in the homepage project and is imported by `getStaticProps` at build time.
+Python was chosen for `add_file.py` and `doctor.py` because it has the lowest barrier to entry for new contributors — Python is pre-installed on macOS and most Linux distributions, requires no project-specific setup (no `package.json`, no build step), and its standard library covers URL parsing, file type detection, and JSON processing without additional dependencies. `buildSearchIndex.ts` is TypeScript because it lives in the homepage project and is imported by `getStaticProps` at build time. There is no mandatory language constraint; the guiding principle is minimizing setup friction for contributors.
 
 ## Testing Plan
 

--- a/rfc/004-llm-knowledge-base.md
+++ b/rfc/004-llm-knowledge-base.md
@@ -1,0 +1,367 @@
+# RFC 004: LLM Knowledge Base & Wiki Book
+
+**Status:** Draft
+**Author:** @ben196888
+**Created:** 2026-04-03
+**Related:** [RFC 002](./002-agent-workflow-role-separation.md)
+
+## Description
+
+The project's knowledge is scattered across three disconnected locations: source code in the main repo, 8 markdown pages in a separate GitHub Wiki repo, and 9+ folders of documents on Google Drive. There is no unified view, no search, and no structured way to add new material. Contributors must manually navigate between GitHub, Google Drive, and the wiki to understand the project.
+
+Inspired by the pattern described in Andrej Karpathy's "LLM Knowledge Bases" post — where raw data is collected, then compiled by an LLM into an interlinked markdown wiki — this RFC establishes an LLM-powered knowledge base for Open StarTer Village. Raw sources stay where they are; the LLM reads from all of them and compiles a wiki book of organized articles within the main repo, viewable and searchable from the homepage.
+
+## Goals
+
+- Catalog all project assets (source code, wiki repo, Google Drive) into a single master inventory without moving any files
+- Compile an LLM-maintained wiki book (~8-10 interlinked markdown articles) from all raw sources
+- Provide a `/add-file` command to incrementally ingest new material (markdown, Drive links, images, videos) and auto-update the wiki
+- Provide a `/doctor` command to lint the wiki for broken links, stale content, and missing cross-references
+- Integrate the wiki book into the homepage project with a viewer and client-side search
+- Expose all capabilities through both Cursor skills and Claude Code slash commands
+- Make the `knowledge/` folder compatible with Obsidian as a nice-to-have
+
+## Non-Goals
+
+- Moving or reorganizing Google Drive files (they stay on Drive)
+- Per-file documentation of source code (one summary article instead)
+- Moving wiki repo content into the main repo (the wiki repo stays as a sibling clone)
+- Server-side search infrastructure (Algolia, ElasticSearch)
+- RAG or vector database (not needed at this scale)
+- Replacing the GitHub Wiki UI (it remains functional for direct edits)
+
+## Solutions
+
+### 1. Directory Structure
+
+The wiki repo and Google Drive stay where they are. The `knowledge/` folder in the main repo holds only the **catalog** (raw/) and **compiled wiki book** (wiki/).
+
+```
+open-star-ter-village/
+├── knowledge/
+│   ├── raw/                          # Catalog + ingested files (article's raw/)
+│   │   ├── _catalog.md              # Master inventory of all sources
+│   │   └── files/                   # Ingested local files (via /add-file)
+│   │       ├── *.md                 # Markdown articles, notes, clipped web pages
+│   │       ├── *.png / *.jpg        # Images
+│   │       └── *.mp4 / *.webm      # Videos
+│   │
+│   └── wiki/                         # LLM-compiled wiki book (article's wiki/)
+│       ├── _index.md                 # Master index with summaries + backlinks
+│       ├── project-overview.md       # Source code summary
+│       ├── game-rules.md             # Game rules compiled from wiki + Drive
+│       ├── game-mechanics.md         # Card types, phases, state model
+│       ├── architecture.md           # Webapp + homepage tech overview
+│       ├── roadmap.md                # Consolidated roadmap with status
+│       ├── contributing.md           # How to contribute
+│       ├── resources.md              # Google Drive catalog (links, descriptions)
+│       └── homepage-editing.md       # CMS editing guide
+│
+├── .claude/commands/                 # Claude Code slash commands
+│   ├── add-file.md                  # /add-file <path-or-url>
+│   ├── doctor.md                    # /doctor [--fix]
+│   └── build-search-index.md       # /build-search-index
+│
+├── .cursor/skills/knowledge-base/   # Cursor skill
+│   ├── SKILL.md                     # Auto-triggers on KB-related queries
+│   └── references/
+│       └── catalog-format.md        # Catalog entry format spec
+│
+├── homepage/src/
+│   ├── pages/wiki/
+│   │   ├── index.jsx                # Wiki listing page
+│   │   └── [...slug].jsx           # Dynamic wiki page renderer
+│   ├── components/
+│   │   └── WikiSearch.jsx           # Search UI component
+│   └── lib/
+│       ├── repository/
+│       │   └── wikiRepository.js    # Read wiki .md at build time
+│       └── service/
+│           └── buildSearchIndex.ts  # Search index builder (importable + CLI)
+│
+└── scripts/wiki/
+    ├── add_file.py                  # File ingestion mechanics
+    └── doctor.py                    # Wiki health checker
+```
+
+**External sources (not in the main repo):**
+- Wiki repo: `../open-star-ter-village.wiki/` (8 markdown files, sibling clone)
+- Google Drive: [root folder](https://drive.google.com/drive/folders/1d2rlxRLQ_iUVhq9-ZO7BGCjTl1ES2zf6) (9 subfolders, 5+ files)
+
+### 2. Raw Data Catalog
+
+`knowledge/raw/_catalog.md` is an LLM-generated master inventory that catalogs every asset source **by reference**.
+
+**Main repo** — monorepo structure overview (3 sub-projects, their roles, tech stacks). A summary, not an exhaustive per-file listing.
+
+**Wiki repo** (8 pages, cataloged by reference):
+
+| File | Content |
+|------|---------|
+| `Home.md` | Bilingual index; links to subprojects and roadmaps |
+| `關於這個專案-‐-About.md` | Full game rules: flow, open star tree, 12 force cards, 18 event cards, FAQ |
+| `專案規劃-‐-Roadmap.md` | Project-wide roadmap (stages 1-4) |
+| `Homepage-Roadmap.md` | CMS integration stages, download materials |
+| `Webapp-Roadmap.md` | Game logic checklist, TypeScript interfaces, UI wireframe |
+| `網站編輯說明-‐-How-to-Edit-Homepage.md` | Decap CMS editing guide, block types, editorial workflow |
+| `_Footer.md` / `_Sidebar.md` | External links (website, Discord, Drive folders) |
+
+Path reference: `../open-star-ter-village.wiki/<filename>`. Four pages linked from Home.md are missing (Physical/Online intro & roadmap).
+
+**Google Drive** — root folder `1d2rlxRLQ_iUVhq9-ZO7BGCjTl1ES2zf6` with 9 subfolders and 5 files:
+
+| Folder | Description |
+|--------|-------------|
+| 2022 桌遊 活動文件與簡報 | Event documents & presentations |
+| 官方網站區 | Official website section assets |
+| 桌遊內容物資料（含租借範本）| Board game content incl. rental templates |
+| 桌遊教學工具包 - Teaching Toolkit | Teaching toolkit for educators |
+| 社群宣傳(含原ig宣傳帳號專區) | Community promotion materials |
+| 視覺素材 | Visual materials (design assets) |
+| 簡報集中區 | Presentation collection |
+| 線上試玩表格設計 | Online playtest form design |
+| 解謎用資料 | Puzzle materials |
+
+Plus 13 individual Drive links referenced in the codebase (README, homepage resource page, wiki footer). Files stay on Drive; **content is read** via MCP or CLI at compilation time. Google Docs auto-convert to Markdown, Sheets to CSV.
+
+### 3. Wiki Book Compilation
+
+The LLM reads from all three raw sources and produces organized, interlinked articles in `knowledge/wiki/`.
+
+**Compilation process:**
+1. LLM reads wiki repo files via `../open-star-ter-village.wiki/`
+2. LLM reads relevant main repo source files (CLAUDE.md, AGENTS.md, package.json, key entry points)
+3. LLM reads Google Drive document content via the `@modelcontextprotocol/server-gdrive` MCP (Docs→Markdown, Sheets→CSV) or `gws` CLI for recursive folder listing
+4. LLM produces ~8-10 wiki articles organized by concept
+5. Each article includes summaries, backlinks to raw sources (including Drive links), and cross-links to other articles
+6. `_index.md` serves as the auto-maintained master index with brief summaries of all articles
+
+**Initial articles:**
+
+| Article | Primary Sources | Content |
+|---------|----------------|---------|
+| `project-overview.md` | Main repo, CLAUDE.md, AGENTS.md | Monorepo summary, tech stack, sub-project roles |
+| `game-rules.md` | wiki About page, Drive rules PDF | Game flow, actions, settle, end conditions |
+| `game-mechanics.md` | wiki About page | Open star tree tiers, 12 force cards, 18 event cards, FAQ |
+| `architecture.md` | CLAUDE.md, webapp source, homepage source | Two-process webapp, dual state systems, homepage SSG |
+| `roadmap.md` | 3 wiki roadmaps | Consolidated project/webapp/homepage roadmap |
+| `contributing.md` | CONTRIBUTING.md, wiki Home.md | How to contribute, issue/PR guidelines |
+| `resources.md` | Drive links from all sources | All external resources with descriptions |
+| `homepage-editing.md` | wiki editing guide | CMS guide, block types, editorial workflow |
+
+**Obsidian compatibility** (nice-to-have): Standard `[text](./path.md)` links work in both Obsidian and on the web. The `knowledge/` folder can be opened as an Obsidian vault directly without plugins.
+
+### 4. Incremental Ingestion: `/add-file`
+
+A two-part tool for adding new raw material and incrementally updating the wiki.
+
+**Supported input types:**
+
+| Input | Detection | Ingestion | Digestion |
+|-------|-----------|-----------|-----------|
+| Markdown | `.md` extension | Copy to `knowledge/raw/files/` | LLM reads content |
+| Google Drive link | `drive.google.com` or `docs.google.com` URL | Add URL to `_catalog.md` | MCP reads content |
+| Image | `.png`, `.jpg`, `.gif`, `.webp`, `.svg` | Copy to `knowledge/raw/files/` | LLM vision describes |
+| Video | `.mp4`, `.webm` | Copy to `knowledge/raw/files/` | Metadata extraction |
+
+**`scripts/wiki/add_file.py`** handles mechanical ingestion:
+1. Detect input type via `mimetypes` + URL parsing
+2. Copy local files to `knowledge/raw/files/` with timestamped filenames
+3. Validate Drive URLs, extract file/folder ID
+4. Output JSON with type, path/URL, and metadata
+
+**`.claude/commands/add-file.md`** orchestrates LLM-powered steps:
+1. Call `python scripts/wiki/add_file.py <input>`
+2. Digest the content (read file, or Drive doc via MCP, or image via vision)
+3. Append entry to `_catalog.md` with summary
+4. Update relevant wiki articles with new information and backlinks
+5. Create new articles if the material covers uncovered topics
+6. Refresh `_index.md`
+
+Each wiki article includes a Sources section with backlinks:
+
+```markdown
+## Sources
+- [meeting-notes-2026-04.md](../raw/files/meeting-notes-2026-04.md) -- Added 2026-04-03
+- [Game Rules PDF](https://drive.google.com/file/d/1PxPb77Q...) -- Google Drive
+```
+
+### 5. Wiki Health Check: `/doctor`
+
+**`scripts/wiki/doctor.py`** scans the wiki and outputs a JSON report:
+- Broken internal links between wiki articles
+- Stale backlinks to deleted or moved raw files
+- Missing cross-references between related articles
+- Catalog entries without summaries
+- Suggested new article candidates based on uncovered topics
+
+**`.claude/commands/doctor.md`** interprets the report:
+- Explains findings to the user with severity levels
+- With `--fix`: auto-applies safe fixes (broken links, missing cross-refs)
+- Proposes unsafe fixes (content rewrites) for user confirmation
+
+### 6. Homepage Integration
+
+**Wiki viewer** (`homepage/src/pages/wiki/`):
+- `[...slug].jsx` renders wiki markdown at build time via `getStaticPaths` + `getStaticProps`
+- Reuses the existing `gray-matter` + `remark` + `rehype-raw` stack
+- `wikiRepository.js` reads from `../../knowledge/wiki/` (same pattern as existing `_pages/` repository)
+- Wiki-specific layout with sidebar navigation generated from `_index.md`
+
+**Search** (client-side, build-time index):
+- `buildSearchIndex.ts` exports a `buildSearchIndex()` function that reads all wiki articles, extracts title/headings/content, and produces a Fuse.js-compatible index
+- **As a module**: imported by `getStaticProps` in `wiki/index.jsx` to generate the index at build time
+- **As a CLI**: run standalone via `npx ts-node homepage/src/lib/service/buildSearchIndex.ts` to regenerate on demand
+- `WikiSearch.jsx` component with instant fuzzy search results
+- Search index served as static JSON from `public/search-index.json`
+
+**Routes:**
+- `/wiki/` — article listing with search
+- `/wiki/<slug>/` — individual article view
+- Respects existing i18n (`/en/wiki/`, `/zh-Hant/wiki/`)
+
+### 7. Knowledge Base Plugin
+
+The three capabilities are exposed through two discovery surfaces, sharing the same scripts.
+
+**Cursor skill** (`.cursor/skills/knowledge-base/SKILL.md`):
+- Auto-triggers when the user mentions knowledge base, wiki, catalog, ingest, or health check
+- Routes to the appropriate sub-command based on intent
+- Loads `references/catalog-format.md` on demand
+
+**Claude Code commands** (`.claude/commands/`):
+
+| Command | Script | Purpose |
+|---------|--------|---------|
+| `/add-file <path-or-url>` | `scripts/wiki/add_file.py` | Ingest raw file, digest, update wiki + catalog |
+| `/doctor [--fix]` | `scripts/wiki/doctor.py` | Scan wiki health, report issues, optional auto-fix |
+| `/build-search-index` | `homepage/src/lib/service/buildSearchIndex.ts` | Regenerate Fuse.js search index JSON |
+
+Each command follows the pattern of the existing `/review-pr` command, accepting `$ARGUMENTS` and producing structured output.
+
+**CLAUDE.md update**: A "Knowledge Base" section will be added referencing the three commands and the `knowledge/` directory structure, so all agent roles (Planner, Supervisor, Executor per RFC 002) are aware.
+
+### 8. Google Drive Access Tooling
+
+Reading Drive content requires OAuth authentication. Two tools are recommended:
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `@modelcontextprotocol/server-gdrive` | MCP | Primary. LLM reads Drive files natively. Docs→Markdown, Sheets→CSV, Presentations→text. |
+| `gws` (Google Workspace CLI) | CLI | Complementary. Recursive folder listing, structured JSON, batch operations. |
+
+**One-time OAuth setup:**
+1. Create Google Cloud project, enable Drive API
+2. Configure OAuth consent screen
+3. Create OAuth Client ID (Desktop App)
+4. Save credentials (`gcp-oauth.keys.json` for MCP, `gws` uses its own config)
+
+### 9. Data Flow
+
+```mermaid
+flowchart TD
+    subgraph rawSources [Raw Sources - Stay In Place]
+        MainRepo[Main Repo Source Code]
+        WikiRepo["Wiki Repo (sibling clone)"]
+        GDrive["Google Drive (9 folders, 5+ files)"]
+    end
+
+    subgraph tools [Access Tools]
+        FS[Filesystem / git]
+        DriveMCP["MCP: server-gdrive"]
+        GwsCLI["CLI: gws"]
+    end
+
+    subgraph knowledgeRaw ["knowledge/raw/ (catalog)"]
+        Catalog[_catalog.md]
+    end
+
+    subgraph knowledgeWiki [knowledge/wiki/]
+        Index[_index.md]
+        Articles[8-10 Concept Articles]
+    end
+
+    subgraph homepageInt [Homepage Integration]
+        WikiRoute["/wiki/[...slug]"]
+        SearchComp[WikiSearch + Fuse.js]
+        SearchIdx[search-index.json]
+    end
+
+    MainRepo --> FS
+    WikiRepo --> FS
+    GDrive -->|"Docs to MD, Sheets to CSV"| DriveMCP
+    GDrive -->|"folder listing, JSON"| GwsCLI
+
+    FS -->|"read files"| Catalog
+    DriveMCP -->|"read content"| Catalog
+    GwsCLI -->|"list structure"| Catalog
+
+    FS -->|"LLM reads source"| Articles
+    DriveMCP -->|"LLM reads Drive docs"| Articles
+    Catalog -->|"LLM compile"| Articles
+    Articles --> Index
+
+    Articles -->|"getStaticProps"| WikiRoute
+    Articles -->|"buildSearchIndex.ts"| SearchIdx
+    SearchIdx --> SearchComp
+```
+
+## Rejected Solutions
+
+### Importing wiki repo into main repo
+Git subtree or file copy would merge two separate git histories. The wiki repo serves a distinct purpose (GitHub Wiki UI for direct browser edits) and keeping it as a sibling clone avoids merge conflicts while preserving that workflow.
+
+### Git submodule for wiki repo
+Adds CI complexity and requires submodule-aware checkout. A sibling clone with relative path references is simpler for 8 files.
+
+### Server-side search (Algolia, ElasticSearch)
+Overkill for ~10 articles. Fuse.js client-side search fits the SSG model with zero infrastructure cost.
+
+### Separate wiki site
+Fragments the project into multiple deployments. Embedding the wiki viewer in the homepage keeps everything in one Next.js app with shared components and i18n.
+
+### RAG / vector database
+The article notes this is unnecessary at small scale. Auto-maintained index files and brief summaries in `_index.md` enable the LLM to find relevant data without vector search for ~10-20 articles.
+
+### Moving Google Drive files into the repo
+Violates the explicit goal of keeping Drive files in place. Binary assets (PDFs, images, presentations) would bloat the repo. Cataloging with links and reading content via MCP is sufficient.
+
+### Node.js / shell scripts for wiki tooling
+Python was chosen for `add_file.py` and `doctor.py` because it has stronger libraries for URL parsing, file type detection, and JSON processing. `buildSearchIndex.ts` is TypeScript because it lives in the homepage project and is imported by `getStaticProps` at build time.
+
+## Testing Plan
+
+1. **Catalog generation**: Run the LLM compilation against the wiki repo and verify `_catalog.md` contains all 8 wiki pages, 9 Drive subfolders, 5 Drive files, and a main repo summary.
+
+2. **Wiki compilation**: Verify the LLM produces ~8 articles with correct cross-links, backlinks to raw sources, and a valid `_index.md`.
+
+3. **`/add-file` smoke test**: Add each input type and verify:
+   - Markdown: file copied to `knowledge/raw/files/`, catalog updated, relevant wiki article updated with backlink
+   - Drive link: URL added to catalog, content read via MCP, wiki updated
+   - Image: file copied, LLM vision description generated, catalog updated
+   - Video: file copied, metadata extracted, catalog updated
+
+4. **`/doctor` smoke test**: Introduce a broken link in a wiki article, run `/doctor`, verify it detects the issue. Run `/doctor --fix`, verify it repairs the link.
+
+5. **Homepage wiki viewer**: Build the homepage (`cd homepage && yarn build`) and verify:
+   - `/wiki/` lists all articles
+   - `/wiki/project-overview/` renders the article correctly
+   - `/en/wiki/` respects i18n routing
+   - No build errors from the new pages/components
+
+6. **Search**: Verify `buildSearchIndex.ts` produces valid JSON, `WikiSearch.jsx` returns relevant results for queries like "game rules" and "roadmap".
+
+7. **Obsidian**: Open `knowledge/` as an Obsidian vault and verify links between articles work and the graph view shows connections.
+
+8. **Plugin discovery**: Verify the Cursor skill triggers when asking "add a file to the knowledge base" and the Claude Code `/add-file`, `/doctor`, `/build-search-index` commands are available.
+
+## SLAs
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Initial wiki compilation | 8-10 articles covering all raw sources | Articles from the initial proposed list |
+| `/add-file` turnaround | < 2 minutes per file | From invocation to catalog + wiki update complete |
+| `/doctor` scan time | < 30 seconds for ~10 articles | Python script execution time |
+| Search index rebuild | < 10 seconds | TypeScript script, ~10 articles |
+| Homepage build | No regression from adding wiki routes | `yarn build` must pass on CI |
+| Wiki article freshness | Updated within 1 session of raw source change | LLM re-reads and updates during the same work session |

--- a/rfc/TEMPLATE.md
+++ b/rfc/TEMPLATE.md
@@ -1,0 +1,52 @@
+# RFC NNN: Title
+
+**Status:** Draft | In Review | Accepted | In Progress | Complete
+**Author:** @github-handle
+**Created:** YYYY-MM-DD
+**Related:** [Issue #N](https://github.com/ocftw/open-star-ter-village/issues/N)
+
+## Description
+
+Why this change is needed. What problem does it solve? What motivated it?
+
+## Goals
+
+- What this RFC aims to achieve
+- Be specific and measurable where possible
+
+## Non-Goals
+
+- What is explicitly out of scope
+- Prevents scope creep during implementation
+
+## Solutions
+
+Describe the proposed solution in detail. Use subsections for distinct parts.
+
+### 1. First Component
+
+Details...
+
+### 2. Second Component
+
+Details...
+
+## Rejected Solutions
+
+### Alternative A
+What was considered and why it was rejected.
+
+### Alternative B
+What was considered and why it was rejected.
+
+## Testing Plan
+
+1. How to verify the solution works
+2. Include manual and automated test steps
+3. Edge cases to check
+
+## SLAs
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Example metric | Target value | Additional context |


### PR DESCRIPTION
## Summary

Establishes a spec-driven development workflow using RFCs and a multi-agent execution model.

- **`rfc/TEMPLATE.md`** — reusable RFC template with standard sections and lifecycle guidance
- **RFC 001** (`rfc/001-rfc-infrastructure.md`) — bootstraps the RFC process: folder structure, naming conventions, and lifecycle states (Draft → Complete)
- **RFC 002** (`rfc/002-agent-workflow-role-separation.md`) — defines three agent roles (Planner/Opus 4.6, Supervisor/Sonnet 4.6, Executor/Codex gpt-5.4), RFC→Plan→Task scope hierarchy, and parallel review/execution strategy
- **RFC 003** (`rfc/003-permissions-hands-free-execution.md`) — per-role permission guidelines and `.claude/settings.json` allow/deny rules for hands-free execution
- **RFC 004** (`rfc/004-llm-knowledge-base.md`) — proposes an LLM-accessible knowledge base for game rules and card data
- **`AGENTS.md` rewrite** — replaced 254-line generic boilerplate with focused Codex executor instructions aligned to RFC 002
- **`CLAUDE.md`** — adds agent workflow section documenting the RFC→Plan→Task process and tool chain
- **`.claude/settings.json`** — enables `code-review`, `codex`, `typescript-lsp`, and `skill-creator` plugins; sets file/git/build permissions and protected-branch deny rules

## Review Summary

All RFCs were reviewed for structural consistency, cross-reference accuracy, and content gaps. Six items were identified and resolved:

| Severity | Item | Location | Resolution |
|----------|------|----------|------------|
| **Should fix** | Non-Goals vs Section 7 contradiction — permissions listed as out-of-scope but detailed in the same RFC | RFC 002 | Reframed Non-Goals to reference RFC 003; Section 7 intro clarifies it documents convention guidelines, not implementation |
| **Should fix** | No i18n strategy for wiki articles — homepage is bilingual but wiki content appeared monolingual | RFC 004 | Documented wiki as English-only; deferred bilingual content, noting a Cursor skill or chat-based search interface may be a better fit |
| **Should fix** | Python dependency rationale — "stronger libraries" argument was debatable for a Node.js monorepo | RFC 004 | Reframed around lowest barrier to entry (pre-installed, no project setup, stdlib-only); noted no mandatory language constraint |
| **Minor** | `yarn run webapp build` vs `yarn webapp build` inconsistency | CLAUDE.md | Normalized to `yarn webapp build` |
| **Minor** | `/code-review:code-review` skill referenced but doesn't exist | RFC 002 | Added note that the skill is a future deliverable of this RFC |
| **Optional** | `rfc/001-progress/` directory not created | RFC 001 | Deferred — RFC is still in Draft stage |

## Test plan

- [ ] Verify `rfc/` contains template + RFC 001–004
- [ ] Verify `.claude/settings.json` is valid JSON (`jq . .claude/settings.json`)
- [ ] Verify `AGENTS.md` is concise and Codex-parseable
- [ ] `yarn webapp build` passes (no regressions)