### PR TITLE
fix(homepage): disable image optimization to unblock hero image

### DIFF
--- a/homepage/next.config.js
+++ b/homepage/next.config.js
@@ -8,4 +8,7 @@ module.exports = {
     defaultLocale: 'zh-Hant',
   },
   trailingSlash: true,
+  images: {
+    unoptimized: true,
+  },
 };


### PR DESCRIPTION
## Summary

- Hero image (and all images) on https://openstartervillage.ocf.tw/en/ were returning HTTP 500 via the `/_ipx/` image optimization endpoint
- Root cause: Netlify's auto-installed `sharp` binary references `libvips-cpp.so.42` which is absent in the function runtime, causing every `next/image` request to fail
- Fix: set `images: { unoptimized: true }` in `next.config.js` to serve images directly from `public/` and bypass `/_ipx/` entirely

## Test plan

- [ ] Netlify deploy preview shows hero image loading correctly
- [ ] Logo and all section images also render (they were all broken for the same reason)
- [ ] Verify `/_ipx/` requests no longer appear in the network tab (Next.js serves images directly)

## Follow-up (Option B)

A proper fix to restore image optimization is planned:
- Pin `sharp@^0.33.5` in `package.json` with `SHARP_IGNORE_GLOBAL_LIBVIPS=true`
- Add `netlify.toml` to version-control the build config and upgrade Node 18.x → 20.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)