### PR TITLE
docs(rfc): RFC 001 infrastructure — In Review with review notes addressed

### DIFF
--- a/rfc/001-rfc-infrastructure.md
+++ b/rfc/001-rfc-infrastructure.md
@@ -43,13 +43,13 @@ rfc/
 
 **Naming convention:** `NNN-kebab-case-slug.md` where NNN is a zero-padded sequential number.
 
-**Progress folders:** `NNN-progress/` contains review summaries, implementation notes, and other tracking artifacts. Files inside are freeform — no required structure.
+**Progress folders:** `NNN-progress/` contains review summaries, implementation notes, and other tracking artifacts. Files inside use date-prefixed names (e.g. `2026-04-11-review-summary.md`) — no other structure is required.
 
 ### 2. RFC Template
 
 See `rfc/TEMPLATE.md` for the full template. Every RFC must include:
 
-- **Metadata:** Status, Author, Created date, Related issues/PRs
+- **Metadata:** Status, Author, Created date, Related issues/PRs, optional Superseded-By
 - **Description:** The problem and motivation
 - **Goals / Non-Goals:** Scope boundaries
 - **Solutions:** The proposed approach, in detail
@@ -66,8 +66,13 @@ See `rfc/TEMPLATE.md` for the full template. Every RFC must include:
 | **Accepted** | Approved for implementation | Maintainer |
 | **In Progress** | Implementation underway | Author / Executor |
 | **Complete** | Fully implemented and verified | Maintainer |
+| **Abandoned** | Proposal withdrawn or superseded | Author / Maintainer |
 
 Transitions are tracked by updating the `Status` field in the RFC frontmatter. There is no formal approval vote — maintainer judgment applies.
+
+**Time limits:**
+- **Draft:** must advance to In Review, be superseded, or be abandoned within **3 months** of the RFC's first commit date on the main branch.
+- **In Review:** a fixed **1-month window** for the Maintainer to accept, supersede, or abandon the RFC. If no decision is made, the RFC is automatically considered Abandoned.
 
 ### 4. Integration with Agent Workflow
 
@@ -101,12 +106,12 @@ External tools introduce access management overhead and are not version-controll
 
 1. **Template usability:** Verify `TEMPLATE.md` can be copied to create a new RFC with all required sections
 2. **Existing RFC conformance:** Verify RFC 002 (already committed) follows the template structure
-3. **Progress folder:** Create `rfc/001-progress/` and verify it can hold freeform tracking files
-4. **Agent discovery:** Verify that a Claude Code or Codex agent, given the instruction "read the relevant RFC", can find and parse RFCs in `rfc/`
+3. **Progress folder:** Create `rfc/001-progress/` and verify it can hold date-prefixed tracking files
 
 ## SLAs
 
 | Metric | Target | Notes |
 |--------|--------|-------|
-| RFC review turnaround | ≤ 1 week from Draft → In Review decision | Maintainer acknowledges within 1 week |
+| Draft lifespan | ≤ 3 months from first commit on main | Must advance to In Review, be superseded, or be abandoned |
+| In Review window | ≤ 1 month (fixed) | Maintainer must accept, supersede, or abandon; no decision = Abandoned |
 | RFC numbering | Sequential, no gaps | If an RFC is abandoned, its number is not reused |

--- a/rfc/001-rfc-infrastructure.md
+++ b/rfc/001-rfc-infrastructure.md
@@ -1,6 +1,6 @@
 # RFC 001: RFC Infrastructure
 
-**Status:** Draft
+**Status:** In Review
 **Author:** @ben196888
 **Created:** 2026-03-23
 **Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346)

--- a/rfc/001-rfc-infrastructure.md
+++ b/rfc/001-rfc-infrastructure.md
@@ -66,13 +66,13 @@ See `rfc/TEMPLATE.md` for the full template. Every RFC must include:
 | **Accepted** | Approved for implementation | Maintainer |
 | **In Progress** | Implementation underway | Author / Executor |
 | **Complete** | Fully implemented and verified | Maintainer |
-| **Abandoned** | Proposal withdrawn or superseded | Author / Maintainer |
+| **Abandoned** | Proposal withdrawn or timed out; set `Superseded-By` if replaced by another RFC | Author / Maintainer |
 
 Transitions are tracked by updating the `Status` field in the RFC frontmatter. There is no formal approval vote — maintainer judgment applies.
 
 **Time limits:**
-- **Draft:** must advance to In Review, be superseded, or be abandoned within **3 months** of the RFC's first commit date on the main branch.
-- **In Review:** a fixed **1-month window** for the Maintainer to accept, supersede, or abandon the RFC. If no decision is made, the RFC is automatically considered Abandoned.
+- **Draft:** must advance to In Review, be superseded (set `Superseded-By` + Abandoned), or be abandoned within **3 months** of the RFC's merge date into main.
+- **In Review:** a fixed **1-month window** for the Maintainer to accept, supersede, or abandon the RFC. If the window expires with no decision, the Author or Maintainer must update the status to Abandoned.
 
 ### 4. Integration with Agent Workflow
 
@@ -112,6 +112,6 @@ External tools introduce access management overhead and are not version-controll
 
 | Metric | Target | Notes |
 |--------|--------|-------|
-| Draft lifespan | ≤ 3 months from first commit on main | Must advance to In Review, be superseded, or be abandoned |
+| Draft lifespan | ≤ 3 months from merge date into main | Must advance to In Review, be superseded, or be abandoned |
 | In Review window | ≤ 1 month (fixed) | Maintainer must accept, supersede, or abandon; no decision = Abandoned |
 | RFC numbering | Sequential, no gaps | If an RFC is abandoned, its number is not reused |

--- a/rfc/001-rfc-infrastructure.md
+++ b/rfc/001-rfc-infrastructure.md
@@ -1,6 +1,6 @@
 # RFC 001: RFC Infrastructure
 
-**Status:** In Review
+**Status:** Accepted
 **Author:** @ben196888
 **Created:** 2026-03-23
 **Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346)


### PR DESCRIPTION
## Summary

- Moves RFC 001 status from Draft → In Review
- Addresses all minor notes from Opus architectural review

## Changes

- **Abandoned lifecycle state** added to the lifecycle table
- **Superseded-By** added as an optional metadata field in the template spec
- **Progress folder convention** — date-prefixed filenames (e.g. `2026-04-11-review-summary.md`)
- **Time limits** — Draft ≤ 3 months from first commit on main; In Review fixed 1-month window (no decision = Abandoned)
- **SLAs** updated to two explicit deadline rows replacing the vague "review turnaround" row
- **Testing Plan item 4** removed — agent RFC discovery belongs to prompt/exploration process, not this RFC

## Review

Reviewed by Opus 4.6 architectural review — no critical concerns found. Ready to accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)