### PR TITLE
feat(claude): add rfc-review skill

### DIFF
--- a/.claude/skills/rfc-review/SKILL.md
+++ b/.claude/skills/rfc-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: rfc-review
+description: RFC review lifecycle workflow for this project. Use this skill whenever the user asks to review an RFC, start the RFC review process, or move an RFC from Draft to Accepted. Guides Claude through: set status to In Review → Opus review → clarification loop with human → PR + approval → set status to Accepted. Invoke proactively when any RFC file is mentioned in a review context.
+user-invocable: true
+---
+
+# RFC Review Workflow
+
+Covers the full lifecycle from Draft to Accepted. Scripts handle the deterministic steps (status transitions, progress file creation). The Opus review and human clarification loop are the core of the process.
+
+## Scripts
+
+| Script | Usage | Purpose |
+|--------|-------|---------|
+| `scripts/set-status.sh` | `bash set-status.sh <rfc-file> <status>` | Update **Status:** field, commit, push |
+| `scripts/save-review-summary.sh` | `echo "<content>" \| bash save-review-summary.sh <nnn>` | Write dated progress file |
+
+Run scripts from the repo root. Valid status values: `Draft`, `In Review`, `Accepted`, `In Progress`, `Complete`, `Abandoned`.
+
+## Workflow
+
+### 1. Set Status → In Review
+
+```bash
+bash .claude/skills/rfc-review/scripts/set-status.sh <rfc-file> "In Review"
+```
+
+Use a cheap model agent (Codex or Haiku) for this step — it is a mechanical edit.
+
+### 2. Review (Opus)
+
+Spawn an Opus agent with high thinking effort. Provide the full RFC content.
+
+Focus: **Critical Concerns only** — things that would cause the process or feature to fail, block implementation, or create lasting confusion.
+
+Expected output format:
+```
+## Critical Concerns
+<numbered list, or "None">
+
+## Minor Notes
+<numbered list, or "None">
+
+## Verdict
+<Ready to accept / Needs changes>
+```
+
+### 3. Clarification Loop
+
+Present findings to the human. For each **Critical Concern**:
+
+1. Ask the human how they want to resolve it (one concern at a time)
+2. Apply the resolution to the RFC file
+3. Run `/simplify` on the changed RFC
+4. Re-run the Opus review to verify the concern is resolved
+
+Repeat until the Opus review returns no Critical Concerns.
+
+Minor Notes may be addressed at the human's discretion — do not block on them.
+
+### 4. PR + Save Summary + Wait for Approval
+
+Once no Critical Concerns remain:
+
+1. Create a PR: `gh pr create` (makes the review visible on GitHub)
+2. Save the review summary:
+   ```bash
+   echo "<review content>" | bash .claude/skills/rfc-review/scripts/save-review-summary.sh <nnn>
+   ```
+3. Ask the human explicitly: **"Do you approve this RFC?"**
+
+Do not proceed to step 5 until the human says yes.
+
+### 5. Set Status → Accepted
+
+```bash
+bash .claude/skills/rfc-review/scripts/set-status.sh <rfc-file> "Accepted"
+```
+
+Use a cheap model agent (Codex or Haiku) for this step.

--- a/.claude/skills/rfc-review/scripts/save-review-summary.sh
+++ b/.claude/skills/rfc-review/scripts/save-review-summary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: echo "<content>" | save-review-summary.sh <nnn>
+# Writes stdin to rfc/NNN-progress/YYYY-MM-DD-review-summary.md
+
+if [ $# -ne 1 ]; then
+  echo "Usage: echo '<content>' | $0 <nnn>" >&2
+  exit 1
+fi
+
+NNN="$1"
+DATE=$(date +%Y-%m-%d)
+PROGRESS_DIR="rfc/${NNN}-progress"
+OUTPUT_FILE="${PROGRESS_DIR}/${DATE}-review-summary.md"
+
+mkdir -p "${PROGRESS_DIR}"
+cat > "${OUTPUT_FILE}"
+
+echo "✓ Created ${OUTPUT_FILE}"

--- a/.claude/skills/rfc-review/scripts/set-status.sh
+++ b/.claude/skills/rfc-review/scripts/set-status.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: set-status.sh <rfc-file> <new-status>
+# Updates the **Status:** field in an RFC file, commits, and pushes.
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <rfc-file> <new-status>" >&2
+  exit 1
+fi
+
+RFC_FILE="$1"
+NEW_STATUS="$2"
+
+if [ ! -f "${RFC_FILE}" ]; then
+  echo "Error: File not found: ${RFC_FILE}" >&2
+  exit 1
+fi
+
+CURRENT_STATUS=$(grep -m1 '^\*\*Status:\*\*' "${RFC_FILE}" | sed 's/\*\*Status:\*\* //')
+
+if [ -z "${CURRENT_STATUS}" ]; then
+  echo "Error: No **Status:** field found in ${RFC_FILE}" >&2
+  exit 1
+fi
+
+RFC_NUM=$(basename "${RFC_FILE}" | grep -o '^[0-9]*')
+RFC_SLUG=$(basename "${RFC_FILE}" .md | sed 's/^[0-9]*-//')
+
+case "${NEW_STATUS}" in
+  "In Review") COMMIT_MSG="docs(rfc): move RFC ${RFC_NUM} to In Review" ;;
+  "Accepted")  COMMIT_MSG="docs(rfc): accept RFC ${RFC_NUM} ${RFC_SLUG}" ;;
+  "Abandoned") COMMIT_MSG="docs(rfc): abandon RFC ${RFC_NUM} ${RFC_SLUG}" ;;
+  *)           COMMIT_MSG="docs(rfc): update RFC ${RFC_NUM} status to ${NEW_STATUS}" ;;
+esac
+
+# macOS-compatible in-place sed
+sed -i '' "s/^\*\*Status:\*\* .*/**Status:** ${NEW_STATUS}/" "${RFC_FILE}"
+
+git add "${RFC_FILE}"
+git commit -m "${COMMIT_MSG}"
+git push
+
+echo "✓ Updated status: ${CURRENT_STATUS} → ${NEW_STATUS}"
+echo "✓ Committed: ${COMMIT_MSG}"
+echo "✓ Pushed to origin"


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/rfc-review/` — project-level skill that standardises the RFC review lifecycle
- Includes two shell scripts for deterministic steps: `set-status.sh` and `save-review-summary.sh`

## Workflow the skill encodes

1. Set status → In Review (cheap model)
2. Opus review — critical concerns only
3. Clarification loop with human until no critical concerns remain
4. Create PR + save review summary + wait for explicit approval
5. Set status → Accepted (cheap model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)