### PR TITLE
docs(rfc): link discussion issues to RFC 002/003/004 frontmatter

### DIFF
--- a/rfc/002-agent-workflow-role-separation.md
+++ b/rfc/002-agent-workflow-role-separation.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Author:** @ben196888
 **Created:** 2026-03-23
-**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [PR #335](https://github.com/ocftw/open-star-ter-village/pull/335)
+**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [PR #335](https://github.com/ocftw/open-star-ter-village/pull/335), [Discussion #365](https://github.com/ocftw/open-star-ter-village/issues/365)
 
 ## Description
 

--- a/rfc/003-permissions-hands-free-execution.md
+++ b/rfc/003-permissions-hands-free-execution.md
@@ -3,7 +3,7 @@
 **Status:** Draft
 **Author:** @ben196888
 **Created:** 2026-03-23
-**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [RFC 002](./002-agent-workflow-role-separation.md)
+**Related:** [Issue #346](https://github.com/ocftw/open-star-ter-village/issues/346), [RFC 002](./002-agent-workflow-role-separation.md), [Discussion #366](https://github.com/ocftw/open-star-ter-village/issues/366)
 
 ## Description
 

--- a/rfc/004-llm-knowledge-base.md
+++ b/rfc/004-llm-knowledge-base.md
@@ -3,7 +3,7 @@
 **Status:** Draft
 **Author:** @ben196888
 **Created:** 2026-04-03
-**Related:** [RFC 002](./002-agent-workflow-role-separation.md)
+**Related:** [RFC 002](./002-agent-workflow-role-separation.md), [Discussion #367](https://github.com/ocftw/open-star-ter-village/issues/367)
 
 ## Description
 


### PR DESCRIPTION
## Summary
- Add issue links for RFC discussion threads (#365, #366, #367) to `Related` fields in RFC 002/003/004 frontmatter

## Test plan
- [x] Links point to correct GitHub issue URLs (`/issues/`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)