### PR TITLE
fix(webapp): reduce Sentry runtime overhead

### DIFF
--- a/packages/webapp/README.md
+++ b/packages/webapp/README.md
@@ -181,6 +181,13 @@ enabled only when all four GitHub Actions secrets are present:
 the full set, runtime error reporting still works when `SENTRY_DSN` is present,
 but the build skips Sentry source-map upload.
 
+Performance tracing is intentionally deferred for the Fly.io alpha. Do not set
+`tracesSampleRate` or `tracesSampler` for the 256 MB shared CPU deployment
+without re-running production smoke checks and monitoring port `3001` health.
+The boardgame.io server uses explicit Sentry error capture only, with default
+Node auto-instrumentation disabled to avoid OpenTelemetry overhead on the game
+server.
+
 To route errors to Discord:
 
 1. Open the Sentry project:

--- a/packages/webapp/instrumentation-client.ts
+++ b/packages/webapp/instrumentation-client.ts
@@ -7,7 +7,6 @@ if (sentryDsn) {
     dsn: sentryDsn,
     environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
     release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 0.1,
   });
 }
 

--- a/packages/webapp/sentry.server.config.ts
+++ b/packages/webapp/sentry.server.config.ts
@@ -7,6 +7,5 @@ if (sentryDsn) {
     dsn: sentryDsn,
     environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
     release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 0.1,
   });
 }

--- a/packages/webapp/src/server.ts
+++ b/packages/webapp/src/server.ts
@@ -11,10 +11,17 @@ const sentryDsn = process.env.SENTRY_DSN;
 if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
+    defaultIntegrations: false,
     environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
     release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 0.1,
   });
+}
+
+async function captureStartupError(error: unknown) {
+  if (sentryDsn) {
+    Sentry.captureException(error);
+    await Sentry.flush(2000);
+  }
 }
 
 async function serve() {
@@ -31,10 +38,6 @@ async function serve() {
       Origins.LOCALHOST_IN_DEVELOPMENT,
     ],
   });
-
-  if (sentryDsn) {
-    Sentry.setupKoaErrorHandler(server.app);
-  }
 
   server.router.get('/health', (ctx) => {
     ctx.status = 200;
@@ -54,4 +57,8 @@ async function serve() {
   server.run(config);
 }
 
-serve();
+serve().catch(async (error) => {
+  console.error(error);
+  await captureStartupError(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Remove Sentry tracing from the Next client, Next server config, and boardgame.io server.
- Disable default Sentry Node auto-instrumentation in the game server and keep explicit startup error capture.
- Document that performance tracing is deferred for the Fly alpha until the 256 MB shared CPU deployment can be revalidated.

Closes #390.

## Deployment

Test-deployed directly to Fly as release `v10`:

- `registry.fly.io/open-star-ter-village:deployment-01KS9WTYQYN1VMPFTM56G5039E`

Initial production checks passed:

- Fly status: `1 total, 1 passing`
- `https://open-star-ter-village.fly.dev/` returned `200`
- `https://open-star-ter-village.fly.dev:3001/health` returned OK
- `https://open-star-ter-village.fly.dev:3001/games/OpenStarTerVillage` returned `200`

## Validation

- `yarn install --immutable`
- `yarn webapp build`
- `yarn webapp test`
- `yarn webapp exec tsc --noEmit`
- `yarn webapp exec tsc -P tsconfig.server.json --noEmit`
- `git diff --check`

Note: root `npx tsc --noEmit` still prints TypeScript help because the repository has no root `tsconfig.json`; this is unrelated to this change.
