### PR TITLE
feat(webapp): redesign homepage, lobby, and waiting room

### DIFF
--- a/packages/webapp/e2e/game-flow.spec.ts
+++ b/packages/webapp/e2e/game-flow.spec.ts
@@ -5,7 +5,7 @@
  * Scenarios 5–10 cover actions and UI features added in Tasks 10–12
  * (mirror fix, event banner, turn indicator, endActionTurn, contributions).
  *
- * The game boots in DevView at localhost:3000.
+ * The game boots in DevView at localhost:3000/dev.
  * Alice (player 0) always goes first and is the active tab on load.
  * TabPanel only mounts children for the active tab, so there are no duplicate selectors.
  */
@@ -156,7 +156,7 @@ async function selectCompatibleJobAndProjectSlot(
 
 test.describe('Simplified Mode — Action Flow', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/dev');
     await waitForGameReady(page);
   });
 

--- a/packages/webapp/e2e/multiplayer.spec.ts
+++ b/packages/webapp/e2e/multiplayer.spec.ts
@@ -1,41 +1,35 @@
 import { test, expect, Browser, BrowserContext, Page } from '@playwright/test';
 
 test.describe('Landing page', () => {
-  test('shows Play Online button linking to /lobby', async ({ page }) => {
+  test('shows Play button linking to /lobby', async ({ page }) => {
     await page.goto('/');
     const btn = page.getByRole('link', { name: /play online/i });
     await expect(btn).toBeVisible();
     await expect(btn).toHaveAttribute('href', '/lobby');
   });
 
-  test('hides DevView by default in non-production', async ({ page }) => {
+  test('does not render DevView on the landing page', async ({ page }) => {
     await page.goto('/');
-    // DevView section should not be visible on clean landing page
-    // but since NODE_ENV !== 'production' in dev, DevView IS shown
-    // Just verify Play Online is present
-    await expect(page.getByRole('link', { name: /play online/i })).toBeVisible();
+    await expect(page.getByText(/developer view/i)).not.toBeVisible();
   });
 
-  test('shows DevView when ?dev=true', async ({ page }) => {
-    await page.goto('/?dev=true');
-    // DevView renders in dev mode
-    await expect(page.locator('[data-testid="dev-view"], .dev-view, #dev-view').or(
-      page.getByText(/developer/i)
-    ).first()).toBeVisible({ timeout: 10_000 });
+  test('shows DevView on /dev', async ({ page }) => {
+    await page.goto('/dev');
+    await expect(page.getByText(/developer view/i).first()).toBeVisible({ timeout: 10_000 });
   });
 });
 
 test.describe('Lobby page', () => {
-  test('renders Create Match form and Public Matches section', async ({ page }) => {
+  test('renders Create room form and Open lobbies section', async ({ page }) => {
     await page.goto('/lobby');
-    await expect(page.getByRole('heading', { name: /create match/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /public matches/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /create room/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /open lobbies/i })).toBeVisible();
     await expect(page.getByLabel(/player name/i)).toBeVisible();
   });
 
   test('shows error on empty player name submit', async ({ page }) => {
     await page.goto('/lobby');
-    await page.getByRole('button', { name: /create game/i }).click();
+    await page.getByRole('button', { name: /建立房間/ }).click();
     await expect(page.getByText(/enter a player name/i)).toBeVisible();
   });
 
@@ -79,7 +73,7 @@ test.describe('Full multiplayer flow', () => {
     await alicePage.goto('/lobby');
     await alicePage.getByLabel(/player name/i).fill('Alice');
     // Select 3 players (should already be default)
-    await alicePage.getByRole('button', { name: /create game/i }).click();
+    await alicePage.getByRole('button', { name: /建立房間/ }).click();
 
     // Should redirect to /game/[matchID]
     await alicePage.waitForURL(/\/game\//, { timeout: 15_000 });
@@ -87,7 +81,7 @@ test.describe('Full multiplayer flow', () => {
     expect(matchID).toBeTruthy();
 
     // Waiting room visible
-    await expect(alicePage.getByRole('heading', { name: /waiting room/i })).toBeVisible({ timeout: 10_000 });
+    await expect(alicePage.getByRole('heading', { name: /waiting room/i, level: 1 })).toBeVisible({ timeout: 10_000 });
   });
 
   test('Bob joins via lobby', async () => {
@@ -97,7 +91,7 @@ test.describe('Full multiplayer flow', () => {
     await expect(bobPage.getByRole('button', { name: /join/i }).first()).toBeVisible({ timeout: 15_000 });
     await bobPage.getByRole('button', { name: /join/i }).first().click();
     await bobPage.waitForURL(/\/game\//, { timeout: 15_000 });
-    await expect(bobPage.getByRole('heading', { name: /waiting room/i })).toBeVisible({ timeout: 10_000 });
+    await expect(bobPage.getByRole('heading', { name: /waiting room/i, level: 1 })).toBeVisible({ timeout: 10_000 });
   });
 
   test('Charlie joins via direct URL', async () => {
@@ -122,11 +116,11 @@ test.describe('Full multiplayer flow', () => {
   test('Alice starts the game — all players see the board', async () => {
     await alicePage.getByRole('button', { name: /start game/i }).click();
     // All should transition to game board — "Waiting Room" heading disappears
-    await expect(alicePage.getByRole('heading', { name: /waiting room/i })).not.toBeVisible({ timeout: 20_000 });
+    await expect(alicePage.getByRole('heading', { name: /waiting room/i, level: 1 })).not.toBeVisible({ timeout: 20_000 });
     // Board view shows "Room <matchID>" heading
     await expect(alicePage.getByRole('heading', { name: /^room /i })).toBeVisible({ timeout: 20_000 });
     // Bob also transitions
-    await expect(bobPage.getByRole('heading', { name: /waiting room/i })).not.toBeVisible({ timeout: 20_000 });
+    await expect(bobPage.getByRole('heading', { name: /waiting room/i, level: 1 })).not.toBeVisible({ timeout: 20_000 });
   });
 
   test('Observer can view game without credentials', async () => {

--- a/packages/webapp/src/app/dev/page.tsx
+++ b/packages/webapp/src/app/dev/page.tsx
@@ -1,0 +1,44 @@
+import DevView from '@/components/DevView';
+import { Container, Typography } from '@mui/material';
+
+type SearchParamValue = string | string[] | undefined;
+
+function getSearchParamValue(value: SearchParamValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Developer harness (offline multi-view board), moved off the redesigned
+ * homepage. Same gating as before: always on outside production, or with
+ * ?dev=true in production.
+ */
+export default function DevPage({
+  searchParams,
+}: {
+  searchParams?: { demo?: SearchParamValue; dev?: SearchParamValue };
+}) {
+  const demo = getSearchParamValue(searchParams?.demo);
+  const dev = getSearchParamValue(searchParams?.dev);
+  const showDevView = process.env.NODE_ENV !== 'production' || dev === 'true';
+
+  if (!showDevView) {
+    return (
+      <Container maxWidth="md" sx={{ py: 6 }}>
+        <Typography color="text.secondary">
+          Developer View is disabled in production. Append ?dev=true to enable it.
+        </Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <main>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Developer View
+        </Typography>
+        <DevView demo={demo} initialMode="offline" isDev={showDevView} />
+      </Container>
+    </main>
+  );
+}

--- a/packages/webapp/src/app/game/[matchID]/page.tsx
+++ b/packages/webapp/src/app/game/[matchID]/page.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   Alert,
   Box,
@@ -11,17 +10,15 @@ import {
   Card,
   CardContent,
   Container,
-  Divider,
-  IconButton,
-  List,
-  ListItem,
-  ListItemText,
   Snackbar,
   Stack,
-  TextField,
   Typography,
 } from '@mui/material';
 import Boardgame from '@/components/BoardGame';
+import { StickerButton } from '@/components/design';
+import LobbyNav from '@/components/lobby/LobbyNav';
+import Note from '@/components/lobby/Note';
+import SeatCard from '@/components/lobby/SeatCard';
 import { clearCredentials, loadCredentials, type MatchCredentials } from '@/lib/matchCredentials';
 import { usePolling } from '@/lib/usePolling';
 import { useSnackbar } from '@/lib/useSnackbar';
@@ -44,7 +41,6 @@ export default function GameRoomPage() {
   const [match, setMatch] = React.useState<LobbyMatch | null>(null);
   const [credentials, setCredentials] = React.useState<MatchCredentials | null>(null);
   const [credentialsReady, setCredentialsReady] = React.useState(false);
-  const [inviteURL, setInviteURL] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(true);
   const [isLeaving, setIsLeaving] = React.useState(false);
   const [isStarting, setIsStarting] = React.useState(false);
@@ -108,10 +104,6 @@ export default function GameRoomPage() {
       cancelled = true;
     };
   }, [matchID]);
-
-  React.useEffect(() => {
-    setInviteURL(window.location.href);
-  }, []);
 
   const allSeatsFilled = match ? getFilledSeatCount(match) === match.players.length : false;
   const hasStarted = match ? hasHostStarted(match) : false;
@@ -194,22 +186,26 @@ export default function GameRoomPage() {
 
   if (!credentialsReady || isLoading) {
     return (
-      <Container maxWidth="md" sx={{ py: 6 }}>
-        <Typography color="text.secondary">Loading room…</Typography>
-      </Container>
+      <main>
+        <LobbyNav />
+        <div style={{ padding: '40px 64px', color: 'var(--ink-mute)', fontSize: 14 }}>
+          載入房間中… <span className="en-cap">Loading room…</span>
+        </div>
+      </main>
     );
   }
 
   if (errorMessage) {
     return (
-      <Container maxWidth="md" sx={{ py: 6 }}>
-        <Stack spacing={2}>
-          <Alert severity="error">{errorMessage}</Alert>
-          <Button component={Link} href="/lobby" variant="contained">
-            Back to Lobby
-          </Button>
-        </Stack>
-      </Container>
+      <main>
+        <LobbyNav />
+        <div style={{ padding: '40px 64px', display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 640 }}>
+          <Note tone="error">{errorMessage}</Note>
+          <Link href="/lobby" className="btn-sticker" style={{ alignSelf: 'flex-start' }}>
+            回大廳 <span style={{ opacity: 0.8, fontFamily: 'var(--font-en)', fontWeight: 500 }}>· Back to lobby</span>
+          </Link>
+        </div>
+      </main>
     );
   }
 
@@ -257,117 +253,158 @@ export default function GameRoomPage() {
 
   if (match && isAbandoned && !hasStarted) {
     return (
-      <Container maxWidth="md" sx={{ py: 6 }}>
-        <Stack spacing={2}>
-          <Alert severity="info">This room was abandoned.</Alert>
-          <Button component={Link} href="/lobby" variant="contained">
-            Return to Lobby
-          </Button>
-        </Stack>
-      </Container>
+      <main>
+        <LobbyNav />
+        <div style={{ padding: '40px 64px', display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 640 }}>
+          <Note tone="info">這個房間已經解散了。 This room was abandoned.</Note>
+          <Link href="/lobby" className="btn-sticker" style={{ alignSelf: 'flex-start' }}>
+            回大廳 <span style={{ opacity: 0.8, fontFamily: 'var(--font-en)', fontWeight: 500 }}>· Back to lobby</span>
+          </Link>
+        </div>
+      </main>
     );
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 6 }}>
-      <Stack spacing={3}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, flexWrap: 'wrap' }}>
-          <Box>
-            <Typography variant="h4" component="h1" gutterBottom>
-              Waiting Room
-            </Typography>
-            <Typography color="text.secondary">
-              Room ID: <Box component="span" sx={{ fontFamily: 'monospace' }}>{matchID}</Box>
-            </Typography>
-          </Box>
-          <Button component={Link} href="/lobby" variant="outlined">
-            Back to Lobby
-          </Button>
-        </Box>
-
-        {credentials ? (
-          <Alert severity="success">
-            Seat {credentials.playerID} is reserved in this browser. Waiting for everyone to join.
-          </Alert>
-        ) : (
-          <Alert severity="info">
-            This browser has no saved seat for the room. Join from the lobby if you want to claim one.
-          </Alert>
-        )}
-
-        {allSeatsFilled && !hasStarted && (
-          <Alert severity={isHost ? 'info' : 'warning'}>
-            {isHost
-              ? 'All seats are filled. Use Start Game to move everyone into the board.'
-              : 'All seats are filled. Waiting for the host to start the game.'}
-          </Alert>
-        )}
-
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={2}>
-              <Typography variant="h6" component="h2">
-                Players
-              </Typography>
-              <Typography color="text.secondary">
-                {match ? `${getFilledSeatCount(match)} / ${match.players.length} seats filled` : 'Loading seats…'}
-              </Typography>
-              <Divider />
-              <List disablePadding>
-                {match?.players.map((player) => (
-                  <ListItem key={player.id} disableGutters>
-                    <ListItemText
-                      primary={`Seat ${player.id}`}
-                      secondary={hasPlayerName(player) ? player.name : 'Open seat'}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            </Stack>
-          </CardContent>
-        </Card>
-
-        <Card variant="outlined">
-          <CardContent>
-            <Stack spacing={2}>
-              <Typography variant="h6" component="h2">
-                Invite Link
-              </Typography>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                <TextField
-                  value={inviteURL}
-                  InputProps={{ readOnly: true }}
-                  inputProps={{ 'aria-label': 'Invite URL' }}
-                  fullWidth
-                />
-                <IconButton aria-label="Copy invite URL" onClick={() => void handleCopyInviteURL()}>
-                  <ContentCopyIcon />
-                </IconButton>
-              </Box>
-            </Stack>
-          </CardContent>
-        </Card>
-
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
-          <Button onClick={() => void handleRefreshNow()} variant="text" disabled={isRefreshing}>
-            {isRefreshing ? 'Refreshing…' : 'Refresh Now'}
-          </Button>
-          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-            {isHost && credentials && (
-              <Button
-                onClick={handleStartGame}
-                variant="contained"
-                disabled={!allSeatsFilled || isMutating}
+    <main style={{ minHeight: '100vh' }}>
+      <LobbyNav />
+      <div style={{ padding: '32px 64px', maxWidth: 1280, margin: '0 auto' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 32, alignItems: 'start' }}>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+              <h1 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 22, fontWeight: 800 }}>
+                等待玩家加入 <span className="en-cap">Waiting room</span>
+              </h1>
+              <span
+                className="sticker"
+                style={{ background: 'var(--orange-soft)', borderColor: 'var(--orange)' }}
+                data-testid="waiting-for-player-alert"
               >
-                {isStarting ? 'Starting…' : 'Start Game'}
-              </Button>
+                <span style={{ width: 6, height: 6, borderRadius: 999, background: 'var(--orange)' }} />
+                等待中 Waiting
+              </span>
+            </div>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 14, flexWrap: 'wrap' }}>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--ink-soft)' }}>房號</span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 16,
+                  fontWeight: 800,
+                  background: 'white',
+                  border: '1.5px solid var(--ink)',
+                  borderRadius: 10,
+                  padding: '4px 14px',
+                  boxShadow: '0 2px 0 var(--ink)',
+                  letterSpacing: '0.04em',
+                  maxWidth: 360,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {matchID}
+              </span>
+              <StickerButton variant="ghost" size="sm" onClick={() => void handleCopyInviteURL()}>
+                複製連結 · Copy invite link
+              </StickerButton>
+            </div>
+
+            <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {credentials ? (
+                <Note tone="success">
+                  你的座位是 Seat {credentials.playerID}，等其他人加入中。 Seat {credentials.playerID} is
+                  reserved in this browser. Waiting for everyone to join.
+                </Note>
+              ) : (
+                <Note tone="info">
+                  這個瀏覽器沒有座位，想入座請從大廳加入。 This browser has no saved seat for the room —
+                  join from the lobby to claim one.
+                </Note>
+              )}
+
+              {allSeatsFilled && !hasStarted && (
+                <Note tone={isHost ? 'info' : 'warning'}>
+                  {isHost
+                    ? '人到齊了！按「開始遊戲」帶大家進牌桌。 All seats are filled — use Start to move everyone into the board.'
+                    : '人到齊了，等待房主開始。 All seats are filled. Waiting for the host to start the game.'}
+                </Note>
+              )}
+            </div>
+
+            <div
+              style={{ marginTop: 24, display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}
+              data-testid="seat-grid"
+            >
+              {match?.players.map((player) => (
+                <SeatCard
+                  key={player.id}
+                  seatIndex={player.id}
+                  playerName={hasPlayerName(player) ? player.name : undefined}
+                  isHost={player.id === 0 && hasPlayerName(player)}
+                  isYou={credentials?.playerID === String(player.id)}
+                />
+              ))}
+            </div>
+            <div style={{ marginTop: 10, fontSize: 12, color: 'var(--ink-mute)' }}>
+              {match
+                ? `${getFilledSeatCount(match)} / ${match.players.length} 個座位已入座 · seats filled`
+                : '載入座位中… Loading seats…'}
+            </div>
+
+            <div style={{ marginTop: 24, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              {isHost && credentials && (
+                <StickerButton onClick={handleStartGame} disabled={!allSeatsFilled || isMutating}>
+                  {isStarting ? '開始中… · Starting' : '開始遊戲 · Start game'}
+                </StickerButton>
+              )}
+              <StickerButton
+                variant="ghost"
+                onClick={() => void handleRefreshNow()}
+                disabled={isRefreshing}
+              >
+                {isRefreshing ? '更新中…' : '重新整理 · Refresh'}
+              </StickerButton>
+              <StickerButton
+                variant="dark"
+                onClick={() => void handleLeaveMatch()}
+                disabled={isMutating}
+                style={{ marginLeft: 'auto' }}
+              >
+                {isLeaving ? '離開中…' : credentials ? '離開 · Leave match' : '回大廳 · Back to lobby'}
+              </StickerButton>
+            </div>
+            {isHost && credentials && (
+              <div style={{ marginTop: 12, fontSize: 12, color: 'var(--ink-mute)' }}>
+                * 房主在所有座位坐滿後可開始遊戲。
+                <span className="en-cap" style={{ marginLeft: 6 }}>
+                  Host can start once every seat is filled.
+                </span>
+              </div>
             )}
-            <Button onClick={handleLeaveMatch} color="error" variant="outlined" disabled={isMutating}>
-              {isLeaving ? 'Leaving…' : credentials ? 'Leave Match' : 'Back to Lobby'}
-            </Button>
-          </Box>
-        </Box>
-      </Stack>
+          </div>
+
+          {/* Rules-at-a-glance panel */}
+          <div className="paper-card" style={{ padding: 22 }}>
+            <h2 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 15, fontWeight: 800 }}>
+              這場遊戲的目標 <span className="en-cap">Objective</span>
+            </h2>
+            <p style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--ink-soft)', marginTop: 8 }}>
+              收集人力、發起與貢獻開源專案，遊戲結束時影響力分數最高者獲勝。
+            </p>
+            <div className="dotted" style={{ margin: '14px 0' }} />
+            <h2 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 15, fontWeight: 800 }}>
+              一回合三步驟 <span className="en-cap">One round, three steps</span>
+            </h2>
+            <ol style={{ paddingLeft: 18, fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.7, marginTop: 8 }}>
+              <li>翻開事件卡</li>
+              <li>所有玩家依序行動</li>
+              <li>清算分數，補滿人力</li>
+            </ol>
+          </div>
+        </div>
+      </div>
 
       <Snackbar
         open={snackbar.open}
@@ -378,6 +415,6 @@ export default function GameRoomPage() {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Container>
+    </main>
   );
 }

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -175,6 +175,12 @@ button {
   transform: translate(0, 3px);
   box-shadow: 0 1px 0 var(--ink);
 }
+.btn-sticker:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: 0 2px 0 var(--ink);
+}
 
 .btn-sticker.ghost {
   background: white;

--- a/packages/webapp/src/app/lobby/page.tsx
+++ b/packages/webapp/src/app/lobby/page.tsx
@@ -1,24 +1,13 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  Chip,
-  Container,
-  Grid,
-  MenuItem,
-  Snackbar,
-  Stack,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Alert, Snackbar } from '@mui/material';
+import { PaperCard, StickerButton } from '@/components/design';
+import Field from '@/components/lobby/Field';
+import LobbyNav from '@/components/lobby/LobbyNav';
+import Note from '@/components/lobby/Note';
+import Segmented from '@/components/lobby/Segmented';
 import { loadCredentials, saveCredentials, type MatchCredentials } from '@/lib/matchCredentials';
 import { usePolling } from '@/lib/usePolling';
 import { useSnackbar } from '@/lib/useSnackbar';
@@ -44,6 +33,125 @@ function formatDate(timestamp: number): string {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(timestamp);
+}
+
+function CardHeading({
+  icon,
+  iconBackground,
+  zh,
+  en,
+}: {
+  icon: string;
+  iconBackground: string;
+  zh: string;
+  en: string;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div
+        aria-hidden
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 12,
+          background: iconBackground,
+          color: 'white',
+          display: 'grid',
+          placeItems: 'center',
+          border: '2px solid var(--ink)',
+          boxShadow: '0 2px 0 var(--ink)',
+          fontSize: 20,
+          fontWeight: 800,
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </div>
+      <h2 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 16, fontWeight: 800 }}>
+        {zh} <span className="en-cap">{en}</span>
+      </h2>
+    </div>
+  );
+}
+
+function MatchRow({
+  match,
+  seatsFilled,
+  totalSeats,
+  status,
+  joining,
+  disabled,
+  onJoin,
+}: {
+  match: VisibleMatch['match'];
+  seatsFilled: number;
+  totalSeats: number;
+  status: string;
+  joining: boolean;
+  disabled: boolean;
+  onJoin: () => void;
+}) {
+  return (
+    <div
+      data-testid={`match-row-${match.matchID}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: 'white',
+        border: '1.5px solid var(--ink)',
+        borderRadius: 12,
+        boxShadow: '0 2px 0 var(--ink)',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            fontWeight: 700,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {match.matchID}
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--ink-mute)', marginTop: 2 }}>
+          {formatDate(match.createdAt)} · {status}
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+        {Array.from({ length: totalSeats }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 999,
+              background: i < seatsFilled ? 'var(--orange)' : 'white',
+              border: '1.5px solid var(--ink)',
+            }}
+          />
+        ))}
+        <span
+          style={{
+            marginLeft: 4,
+            fontSize: 11,
+            fontWeight: 700,
+            color: 'var(--ink-soft)',
+            fontFamily: 'var(--font-en)',
+          }}
+        >
+          {seatsFilled}/{totalSeats}
+        </span>
+      </div>
+      <StickerButton variant="teal" size="sm" onClick={onJoin} disabled={disabled}>
+        {joining ? '加入中… · Joining' : '加入 · Join'}
+      </StickerButton>
+    </div>
+  );
 }
 
 export default function LobbyPage() {
@@ -163,123 +271,98 @@ export default function LobbyPage() {
   };
 
   return (
-    <Container maxWidth="lg" sx={{ py: 6 }}>
-      <Stack spacing={4}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 2, flexWrap: 'wrap' }}>
-          <Box>
-            <Typography variant="h3" component="h1" gutterBottom>
-              Play Online
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 720 }}>
-              Create a public room, share the room link, and let the host start the live board once every seat is filled.
-            </Typography>
-          </Box>
-          <Button component={Link} href="/" variant="outlined">
-            Back Home
-          </Button>
-        </Box>
+    <main style={{ minHeight: '100vh' }}>
+      <LobbyNav />
+      <div style={{ padding: '40px 64px', maxWidth: 1280, margin: '0 auto' }}>
+        <h1 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 22, fontWeight: 800, marginBottom: 28 }}>
+          開始一場遊戲 <span className="en-cap">Start a session</span>
+        </h1>
 
-        <Grid container spacing={3}>
-          <Grid item xs={12} md={4}>
-            <Card variant="outlined">
-              <CardContent>
-                <Stack spacing={2}>
-                  <Typography variant="h5" component="h2">
-                    Create Match
-                  </Typography>
-                  <TextField
-                    label="Player Name"
-                    value={playerName}
-                    onChange={handlePlayerNameChange}
-                    error={playerName.length > 0 && !playerNameIsValid}
-                    helperText="Use 1 to 20 visible characters."
-                    fullWidth
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, alignItems: 'start' }}>
+          {/* Create room */}
+          <PaperCard padding={28} data-testid="create-room-card">
+            <CardHeading icon="＋" iconBackground="var(--orange)" zh="開新房間" en="Create room" />
+            <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, marginTop: 10 }}>
+              當村長，邀請朋友加入，人到齊後開始遊戲。
+              <br />
+              <span className="en-cap">Host a match — invite up to 6 players.</span>
+            </p>
+
+            <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <Field
+                label="玩家名稱 · Player name"
+                placeholder="你的暱稱"
+                value={playerName}
+                onChange={handlePlayerNameChange}
+                error={playerName.length > 0 && !playerNameIsValid}
+                helper="1 到 20 個字 · Use 1 to 20 visible characters."
+              />
+              <Segmented
+                label="玩家人數 · Players"
+                options={PLAYER_COUNT_OPTIONS}
+                value={numPlayers as (typeof PLAYER_COUNT_OPTIONS)[number]}
+                onChange={(count) => setNumPlayers(count)}
+                disabled={isCreating}
+              />
+            </div>
+            <StickerButton
+              onClick={() => void handleCreateMatch()}
+              disabled={isCreating}
+              style={{ marginTop: 22, width: '100%' }}
+            >
+              {isCreating ? '建立中… · Creating' : '建立房間 · Create'}
+            </StickerButton>
+          </PaperCard>
+
+          {/* Open lobbies */}
+          <PaperCard padding={28} data-testid="open-lobbies-card">
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+              <CardHeading icon="→" iconBackground="var(--teal)" zh="加入房間" en="Open lobbies" />
+              <StickerButton
+                variant="ghost"
+                size="sm"
+                onClick={() => void handleRefreshMatches()}
+                disabled={isRefreshing || isCreating}
+              >
+                {isRefreshing ? '更新中…' : '重新整理 · Refresh'}
+              </StickerButton>
+            </div>
+            <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, marginTop: 10 }}>
+              從清單裡選一個公開房間加入。
+              <br />
+              <span className="en-cap">Pick a public room from the list.</span>
+            </p>
+
+            <div className="dotted" style={{ margin: '18px 0' }} />
+
+            {isLoading ? (
+              <div style={{ fontSize: 13, color: 'var(--ink-mute)' }}>載入中… Loading matches…</div>
+            ) : loadError ? (
+              <Note tone="error">Unable to load matches. Check your connection and try refreshing.</Note>
+            ) : matches.length === 0 ? (
+              <Note tone="info">
+                目前沒有等待中的公開房間，開一間吧！ No public matches are waiting right now — create
+                one to get started.
+              </Note>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8, maxHeight: 320, overflow: 'auto' }}>
+                {matches.map(({ match, seatsFilled, totalSeats, status }) => (
+                  <MatchRow
+                    key={match.matchID}
+                    match={match}
+                    seatsFilled={seatsFilled}
+                    totalSeats={totalSeats}
+                    status={status}
+                    joining={joiningMatchID === match.matchID}
+                    disabled={status !== 'Waiting' || joiningMatchID !== null || isCreating}
+                    onJoin={() => void handleJoinMatch(match.matchID)}
                   />
-                  <TextField
-                    select
-                    label="Players"
-                    value={numPlayers}
-                    onChange={(event) => setNumPlayers(Number(event.target.value))}
-                    fullWidth
-                  >
-                    {PLAYER_COUNT_OPTIONS.map((count) => (
-                      <MenuItem key={count} value={count}>
-                        {count} players
-                      </MenuItem>
-                    ))}
-                  </TextField>
-                </Stack>
-              </CardContent>
-              <CardActions sx={{ px: 2, pb: 2 }}>
-                <Button onClick={handleCreateMatch} variant="contained" disabled={isCreating} fullWidth>
-                  {isCreating ? 'Creating…' : 'Create Game'}
-                </Button>
-              </CardActions>
-            </Card>
-          </Grid>
-
-          <Grid item xs={12} md={8}>
-            <Card variant="outlined">
-              <CardContent>
-                <Stack spacing={2}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                    <Typography variant="h5" component="h2">
-                      Public Matches
-                    </Typography>
-                    <Button onClick={() => void handleRefreshMatches()} variant="text" disabled={isRefreshing || isCreating}>
-                      {isRefreshing ? 'Refreshing…' : 'Refresh'}
-                    </Button>
-                  </Box>
-
-                  {isLoading ? (
-                    <Typography color="text.secondary">Loading matches…</Typography>
-                  ) : loadError ? (
-                    <Alert severity="error">Unable to load matches. Check your connection and try refreshing.</Alert>
-                  ) : matches.length === 0 ? (
-                    <Alert severity="info">No public matches are waiting right now. Create one to get started.</Alert>
-                  ) : (
-                    <Stack spacing={2}>
-                      {matches.map(({ match, seatsFilled, totalSeats, status }) => (
-                        <Card key={match.matchID} variant="outlined">
-                          <CardContent>
-                            <Stack spacing={1.5}>
-                              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                                <Typography variant="h6" component="h3" sx={{ fontFamily: 'monospace' }}>
-                                  {match.matchID}
-                                </Typography>
-                                <Chip
-                                  label={status}
-                                  color={status === 'Waiting' ? 'success' : 'default'}
-                                  size="small"
-                                />
-                              </Box>
-                              <Typography variant="body2" color="text.secondary">
-                                Seats filled: {seatsFilled} / {totalSeats}
-                              </Typography>
-                              <Typography variant="body2" color="text.secondary">
-                                Created: {formatDate(match.createdAt)}
-                              </Typography>
-                            </Stack>
-                          </CardContent>
-                          <CardActions sx={{ px: 2, pb: 2 }}>
-                            <Button
-                              onClick={() => void handleJoinMatch(match.matchID)}
-                              variant="contained"
-                              disabled={status !== 'Waiting' || joiningMatchID !== null || isCreating}
-                            >
-                              {joiningMatchID === match.matchID ? 'Joining…' : 'Join'}
-                            </Button>
-                          </CardActions>
-                        </Card>
-                      ))}
-                    </Stack>
-                  )}
-                </Stack>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
-      </Stack>
+                ))}
+              </div>
+            )}
+          </PaperCard>
+        </div>
+      </div>
 
       <Snackbar
         open={snackbar.open}
@@ -290,6 +373,6 @@ export default function LobbyPage() {
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Container>
+    </main>
   );
 }

--- a/packages/webapp/src/app/page.tsx
+++ b/packages/webapp/src/app/page.tsx
@@ -1,48 +1,137 @@
-import DevView from "@/components/DevView";
 import Link from 'next/link';
-import { Box, Button, Container, Stack, Typography } from '@mui/material';
+import { CharacterAvatar } from '@/components/design';
+import type { JobRole } from '@/components/design';
+import LobbyNav from '@/components/lobby/LobbyNav';
 
-type SearchParamValue = string | string[] | undefined;
+const HOMEPAGE_URL = 'https://openstartervillage.ocf.tw';
 
-function getSearchParamValue(value: SearchParamValue): string | undefined {
-  return Array.isArray(value) ? value[0] : value;
-}
+const STATS = [
+  { value: '3–6', zh: '玩家', en: 'PLAYERS' },
+  { value: '~60', zh: '分鐘', en: 'MINUTES' },
+  { value: '70+', zh: '專案卡', en: 'PROJECTS' },
+] as const;
 
-export default function Home({
-  searchParams,
-}: {
-  searchParams?: { demo?: SearchParamValue; mode?: SearchParamValue; dev?: SearchParamValue };
-}) {
-  const demo = getSearchParamValue(searchParams?.demo);
-  const dev = getSearchParamValue(searchParams?.dev);
-  const showDevView = process.env.NODE_ENV !== 'production' || dev === 'true';
+/** Floating character stickers on the hero's right side. */
+const HERO_CHARACTERS: Array<{ role: JobRole; zh: string; rotate: number; x: string; y: string }> = [
+  { role: 'eng', zh: '工程師', rotate: -6, x: '4%', y: '6%' },
+  { role: 'design', zh: '美術設計', rotate: 5, x: '56%', y: '0%' },
+  { role: 'civil', zh: '公務人員', rotate: 3, x: '10%', y: '52%' },
+  { role: 'issue', zh: '議題工作者', rotate: -4, x: '62%', y: '46%' },
+  { role: 'writer', zh: '文字工作者', rotate: 8, x: '34%', y: '26%' },
+];
 
+export default function Home() {
   return (
-    <main>
-      <Container maxWidth="lg" sx={{ py: 6 }}>
-        <Stack spacing={4}>
-          <Box>
-            <Typography variant="h2" component="h1" gutterBottom>
-              Open StarTer Village
-            </Typography>
-            <Typography variant="h6" color="text.secondary" sx={{ maxWidth: 720, mb: 3 }}>
-              Create an online room for 3 to 6 players, share the invite link, and start the live board once every seat is filled.
-            </Typography>
-            <Button component={Link} href="/lobby" variant="contained" size="large">
-              Play Online
-            </Button>
-          </Box>
+    <main style={{ minHeight: '100vh' }}>
+      <LobbyNav />
+      <div
+        style={{
+          padding: '48px 64px',
+          display: 'grid',
+          gridTemplateColumns: '1.1fr 0.9fr',
+          gap: 48,
+          alignItems: 'center',
+          maxWidth: 1280,
+          margin: '0 auto',
+        }}
+      >
+        <div>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'var(--orange-soft)',
+              color: 'var(--orange-deep)',
+              border: '1.5px solid var(--orange)',
+              borderRadius: 999,
+              padding: '5px 14px',
+              fontSize: 12,
+              fontWeight: 700,
+              marginBottom: 18,
+            }}
+          >
+            🎲 桌遊上線版 · Now playable online
+          </div>
+          <h1 className="h-display" style={{ fontSize: 56 }}>
+            一起來蓋
+            <br />
+            <span style={{ color: 'var(--orange)' }}>開源</span>之村
+          </h1>
+          <p
+            style={{
+              fontFamily: 'var(--font-en)',
+              fontSize: 16,
+              color: 'var(--ink-soft)',
+              marginTop: 12,
+              lineHeight: 1.45,
+            }}
+          >
+            Build open-source projects together. Recruit your team,
+            <br />
+            ship contributions, and discover what open really means.
+          </p>
+          <div style={{ display: 'flex', gap: 12, marginTop: 28, flexWrap: 'wrap' }}>
+            <Link href="/lobby" className="btn-sticker">
+              開始遊戲{' '}
+              <span style={{ opacity: 0.8, fontFamily: 'var(--font-en)', fontWeight: 500 }}>
+                · Play online
+              </span>
+            </Link>
+            <a href={HOMEPAGE_URL} target="_blank" rel="noreferrer" className="btn-sticker ghost">
+              如何遊玩{' '}
+              <span style={{ opacity: 0.6, fontFamily: 'var(--font-en)', fontWeight: 500 }}>
+                · How to play
+              </span>
+            </a>
+          </div>
 
-          {showDevView && (
-            <Box>
-              <Typography variant="h4" component="h2" gutterBottom>
-                Developer View
-              </Typography>
-              <DevView demo={demo} initialMode="offline" isDev={showDevView} />
-            </Box>
-          )}
-        </Stack>
-      </Container>
+          <div style={{ display: 'flex', gap: 24, marginTop: 36 }}>
+            {STATS.map((stat) => (
+              <div key={stat.en}>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-en)',
+                    fontWeight: 900,
+                    fontSize: 28,
+                    color: 'var(--ink)',
+                  }}
+                >
+                  {stat.value}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--ink-soft)', fontWeight: 600 }}>
+                  {stat.zh}
+                </div>
+                <div className="en-cap" style={{ marginTop: 2 }}>
+                  {stat.en}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right: floating character stickers (card components arrive in PR 3) */}
+        <div style={{ position: 'relative', height: 420 }} aria-hidden>
+          {HERO_CHARACTERS.map((c) => (
+            <div
+              key={c.role}
+              style={{
+                position: 'absolute',
+                left: c.x,
+                top: c.y,
+                transform: `rotate(${c.rotate}deg)`,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              <CharacterAvatar role={c.role} size="xl" />
+              <span className="sticker">{c.zh}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </main>
   );
 }

--- a/packages/webapp/src/components/lobby/Field.tsx
+++ b/packages/webapp/src/components/lobby/Field.tsx
@@ -1,0 +1,47 @@
+import { InputHTMLAttributes, ReactNode, useId } from 'react';
+
+type FieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  /** Bilingual label, e.g. "玩家名稱 · Player name" */
+  label: string;
+  /** Muted helper or error text below the input */
+  helper?: ReactNode;
+  error?: boolean;
+};
+
+export default function Field({ label, helper, error = false, ...inputProps }: FieldProps) {
+  const id = useId();
+  return (
+    <div>
+      <label className="en-cap" htmlFor={id} style={{ display: 'block', marginBottom: 6 }}>
+        {label}
+      </label>
+      <input
+        id={id}
+        {...inputProps}
+        style={{
+          width: '100%',
+          padding: '10px 14px',
+          background: 'white',
+          border: `1.5px solid ${error ? 'var(--orange-deep)' : 'var(--ink)'}`,
+          borderRadius: 10,
+          fontSize: 14,
+          fontFamily: 'var(--font-zh)',
+          boxShadow: 'inset 0 2px 0 rgba(0,0,0,0.04)',
+          outline: 'none',
+          ...inputProps.style,
+        }}
+      />
+      {helper && (
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 12,
+            color: error ? 'var(--orange-deep)' : 'var(--ink-mute)',
+          }}
+        >
+          {helper}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/webapp/src/components/lobby/LobbyNav.tsx
+++ b/packages/webapp/src/components/lobby/LobbyNav.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { Logo } from '@/components/design';
+
+const HOMEPAGE_URL = 'https://openstartervillage.ocf.tw';
+const GITHUB_URL = 'https://github.com/ocftw/open-star-ter-village';
+
+export default function LobbyNav() {
+  return (
+    <nav
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '18px 36px',
+        borderBottom: '1.5px solid var(--paper-3)',
+      }}
+    >
+      <Link href="/" aria-label="回首頁 Home">
+        <Logo />
+      </Link>
+      <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+        <a
+          href={HOMEPAGE_URL}
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
+        >
+          規則 <span className="en-cap">Rules</span>
+        </a>
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noreferrer"
+          style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
+        >
+          GitHub
+        </a>
+      </div>
+    </nav>
+  );
+}

--- a/packages/webapp/src/components/lobby/Note.tsx
+++ b/packages/webapp/src/components/lobby/Note.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+
+type NoteTone = 'info' | 'success' | 'warning' | 'error';
+
+const TONES: Record<NoteTone, { bg: string; border: string; ink: string }> = {
+  info: { bg: 'var(--teal-soft)', border: 'var(--teal-deep)', ink: 'var(--teal-deep)' },
+  success: { bg: '#dcf3e3', border: '#1f7a3a', ink: '#1f7a3a' },
+  warning: { bg: 'var(--orange-soft)', border: 'var(--orange-deep)', ink: 'var(--orange-deep)' },
+  error: { bg: '#f8dcd7', border: 'var(--proj-data)', ink: 'var(--proj-data)' },
+};
+
+type NoteProps = {
+  tone?: NoteTone;
+  children: ReactNode;
+  'data-testid'?: string;
+};
+
+/** Sticker-style inline alert replacing MUI <Alert> on redesigned screens. */
+export default function Note({ tone = 'info', children, ...rest }: NoteProps) {
+  const colors = TONES[tone];
+  return (
+    <div
+      role="status"
+      {...rest}
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 8,
+        padding: '10px 16px',
+        background: colors.bg,
+        border: `1.5px solid ${colors.border}`,
+        borderRadius: 12,
+        boxShadow: '0 2px 0 ' + colors.border,
+        fontSize: 13,
+        lineHeight: 1.5,
+        color: colors.ink,
+        fontWeight: 600,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/webapp/src/components/lobby/SeatCard.tsx
+++ b/packages/webapp/src/components/lobby/SeatCard.tsx
@@ -1,0 +1,121 @@
+import { PLAYER_COLORS } from '@/components/design';
+
+type SeatCardProps = {
+  seatIndex: number;
+  playerName?: string;
+  isHost?: boolean;
+  isYou?: boolean;
+};
+
+export default function SeatCard({
+  seatIndex,
+  playerName,
+  isHost = false,
+  isYou = false,
+}: SeatCardProps) {
+  if (!playerName) {
+    return (
+      <div
+        className="hatch"
+        data-testid={`seat-${seatIndex}-empty`}
+        style={{
+          height: 108,
+          border: '2px dashed var(--ink-mute)',
+          borderRadius: 16,
+          display: 'grid',
+          placeItems: 'center',
+          color: 'var(--ink-mute)',
+          fontSize: 12,
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
+        <div style={{ textAlign: 'center' }}>
+          <div style={{ fontSize: 22 }}>＋</div>
+          <div>Seat {seatIndex}</div>
+        </div>
+      </div>
+    );
+  }
+
+  const seatColor = PLAYER_COLORS[seatIndex % PLAYER_COLORS.length];
+  return (
+    <div
+      data-testid={`seat-${seatIndex}-filled`}
+      style={{
+        height: 108,
+        background: 'white',
+        border: '2px solid var(--ink)',
+        borderRadius: 16,
+        boxShadow: 'var(--shadow-sticker)',
+        padding: 14,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        position: 'relative',
+      }}
+    >
+      {isHost && (
+        <div
+          style={{
+            position: 'absolute',
+            top: -10,
+            right: 10,
+            background: 'var(--orange)',
+            color: 'white',
+            padding: '2px 8px',
+            borderRadius: 999,
+            border: '1.5px solid var(--ink)',
+            boxShadow: '0 2px 0 var(--ink)',
+            fontSize: 10,
+            fontWeight: 800,
+          }}
+        >
+          HOST 房主
+        </div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 999,
+            background: seatColor,
+            color: 'white',
+            border: '2px solid var(--ink)',
+            display: 'grid',
+            placeItems: 'center',
+            fontFamily: 'var(--font-en)',
+            fontWeight: 800,
+            fontSize: 14,
+            boxShadow: '0 2px 0 var(--ink)',
+            flexShrink: 0,
+          }}
+        >
+          {playerName[0]?.toUpperCase()}
+        </span>
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              fontWeight: 800,
+              fontSize: 14,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {playerName}
+          </div>
+          <div className="en-cap">
+            Seat {seatIndex}
+            {isYou ? ' · YOU' : ''}
+          </div>
+        </div>
+      </div>
+      <div style={{ marginTop: 'auto' }}>
+        <span className="sticker" style={{ background: '#dcf3e3', borderColor: '#1f7a3a', color: '#1f7a3a' }}>
+          ✓ 已入座 Seated
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/webapp/src/components/lobby/Segmented.tsx
+++ b/packages/webapp/src/components/lobby/Segmented.tsx
@@ -1,0 +1,54 @@
+type SegmentedProps<T extends string | number> = {
+  /** Bilingual label, e.g. "玩家人數 · Players" */
+  label: string;
+  options: readonly T[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+};
+
+export default function Segmented<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+  disabled = false,
+}: SegmentedProps<T>) {
+  return (
+    <div role="group" aria-label={label}>
+      <div className="en-cap" style={{ marginBottom: 6 }}>
+        {label}
+      </div>
+      <div style={{ display: 'flex', gap: 6 }}>
+        {options.map((option) => {
+          const selected = option === value;
+          return (
+            <button
+              key={option}
+              type="button"
+              aria-pressed={selected}
+              disabled={disabled}
+              onClick={() => onChange(option)}
+              style={{
+                flex: 1,
+                padding: '8px 0',
+                background: selected ? 'var(--ink)' : 'white',
+                color: selected ? 'white' : 'var(--ink)',
+                border: '1.5px solid var(--ink)',
+                borderRadius: 10,
+                fontWeight: 700,
+                fontSize: 13,
+                fontFamily: 'var(--font-en)',
+                boxShadow: selected ? 'none' : '0 2px 0 var(--ink)',
+                transform: selected ? 'translateY(2px)' : 'none',
+                opacity: disabled ? 0.5 : 1,
+              }}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Part 2 of 5 of the webapp UI redesign — see RFC #399 (and its 2026-07-10 finalized-decisions comment). Builds on #400.

## What

- **Homepage** rebuilt as the mock's cover-style landing: bilingual hero, official character stickers, stats row, 開始遊戲 · Play online → `/lobby`, 如何遊玩 · How to play → openstartervillage.ocf.tw. Now a static route (94 kB first-load vs 235 kB before — MUI left the page).
- **DevView** moved to a dedicated `/dev` route, unredesigned, same production gating (`?dev=true`).
- **Lobby** re-skinned: sticker create-room form (name + segmented 3–6 player count) and open-lobbies list with seat dots. **Visual parity only** — `actions.ts`, polling, credential handling untouched; room name/visibility/code deliberately omitted per RFC decision.
- **Waiting room** re-skinned: seat cards with player colors + HOST badge, hatch empty seats, copy-invite-link, host start button, rules-at-a-glance panel. Started-game branch (board render) untouched — that's PR 3.
- New `src/components/lobby/` primitives: `LobbyNav`, `Field`, `Segmented`, `Note`, `SeatCard`; `btn-sticker` gains a `:disabled` state.
- e2e specs updated for the new markup (`/dev` route, bilingual buttons, h1-scoped waiting-room heading).

## Verification

- `yarn lint` ✓ · `yarn test` 52/52 ✓ · `yarn build:next` ✓
- Playwright e2e: `multiplayer.spec.ts` 13/13 ✓, `game-flow.spec.ts` 10/10 ✓ (run against `dev:next` + game server on :3001)
- Runtime evidence with a live 3-player room in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
