### PR TITLE
feat(webapp): mobile bottom-sheet board and responsive lobby

### DIFF
--- a/packages/webapp/e2e/game-flow.spec.ts
+++ b/packages/webapp/e2e/game-flow.spec.ts
@@ -51,11 +51,30 @@ async function expectScore(page: Page, name: string, score: number) {
   await expect(page.locator(`[data-testid="player-status-${name}"]`)).toHaveAttribute('data-score', String(score));
 }
 
-/** End the current player's action turn: idle bar → 結束我的回合 → confirm. */
+/**
+ * End the current player's action turn: idle bar → 結束我的回合 → confirm.
+ *
+ * When the 四大自由 event is in play and this player is the round's last, the
+ * server intercepts endActionTurn with a forced 2-card discard — handle it so
+ * the turn actually advances regardless of which event was drawn.
+ */
 async function performEndTurn(page: Page): Promise<void> {
   await page.locator('[data-testid="end-turn"]').click();
   await expect(contextAction(page)).toHaveAttribute('data-mode', 'endActionTurn');
   await confirmButton(page).click();
+
+  const discardPanel = page.locator('[data-testid="discard-job-cards-panel"]');
+  const needsDiscard = await discardPanel
+    .waitFor({ state: 'visible', timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (needsDiscard) {
+    const jobCards = page.locator('[data-testid^="job-card-"]');
+    await jobCards.nth(0).click();
+    await jobCards.nth(1).click();
+    await page.locator('[data-testid="discard-confirm"]').click();
+    await discardPanel.waitFor({ state: 'hidden', timeout: 5000 });
+  }
 }
 
 /**
@@ -63,34 +82,59 @@ async function performEndTurn(page: Page): Promise<void> {
  * (enters create mode), then tap a matching job card. Returns the job name used.
  *
  * @param requireMultipleJobTypes - when true, prefer hand cards with 2+ different
- *   job requirements so a different job type remains for a subsequent recruit.
+ *   job requirements — and (pass 1) an unclaimed job needing > 2 points — so a
+ *   recruit + contribute on this project stays possible afterwards.
  */
 async function selectCompatibleHandAndJobCard(page: Page, requireMultipleJobTypes = false): Promise<string> {
   const handCards = page.locator('[data-testid^="hand-card-"]');
   const jobCards  = page.locator('[data-testid^="job-card-"]');
 
-  const passes = requireMultipleJobTypes ? [true, false] : [false];
+  // Job names currently available in the market. Creating consumes only the
+  // clicked card, so any OTHER job type present now is still recruitable after.
+  const marketJobs: string[] = [];
+  for (let j = 0, n = await jobCards.count(); j < n; j++) {
+    const name = (await jobCards.nth(j).getAttribute('data-job-name'))?.trim();
+    if (name) marketJobs.push(name);
+  }
 
-  for (const requireMulti of passes) {
+  // Pass 1 (strictest) → pass N (anything compatible).
+  const passes = requireMultipleJobTypes ? ['multi-with-room', 'multi', 'any'] : ['any'];
+
+  for (const pass of passes) {
     const handCount = await handCards.count();
     for (let h = 0; h < handCount; h++) {
       const handCard = handCards.nth(h);
       const requirements = await handCard.getAttribute('data-requirements');
       if (!requirements) continue;
       const reqList = requirements.split(',').map(r => r.trim()).filter(Boolean);
-      if (requireMulti && reqList.length < 2) continue;
+      if (pass !== 'any' && reqList.length < 2) continue;
+      const jobReqJson = await handCard.getAttribute('data-job-requirements');
+      const jobReqMap: Record<string, number> = jobReqJson ? JSON.parse(jobReqJson) : {};
 
       const jobCount = await jobCards.count();
       for (let j = 0; j < jobCount; j++) {
         const jobCard = jobCards.nth(j);
         const jobName = (await jobCard.getAttribute('data-job-name'))?.trim() ?? '';
-        if (reqList.includes(jobName)) {
-          await handCard.click();
-          // Tapping a hand card from idle must enter create mode (inference works).
-          await expect(contextAction(page)).toHaveAttribute('data-mode', 'createProject');
-          await jobCard.click();
-          return jobName;
-        }
+        if (!reqList.includes(jobName)) continue;
+        // Multi passes: some OTHER required job must be available in the market
+        // so the follow-up recruit can find a match; the strictest pass also
+        // wants that job to need > 2 points, so the recruit's initial
+        // contribution (2) still leaves room to contribute afterwards.
+        const INITIAL_CONTRIBUTION = 2;
+        const hasRecruitableOther = (needRoom: boolean) =>
+          reqList.some(
+            (r) =>
+              r !== jobName &&
+              marketJobs.includes(r) &&
+              (!needRoom || (jobReqMap[r] ?? 0) > INITIAL_CONTRIBUTION),
+          );
+        if (pass === 'multi-with-room' && !hasRecruitableOther(true)) continue;
+        if (pass === 'multi' && !hasRecruitableOther(false)) continue;
+        await handCard.click();
+        // Tapping a hand card from idle must enter create mode (inference works).
+        await expect(contextAction(page)).toHaveAttribute('data-mode', 'createProject');
+        await jobCard.click();
+        return jobName;
       }
     }
   }

--- a/packages/webapp/e2e/mobile.spec.ts
+++ b/packages/webapp/e2e/mobile.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Mobile smoke tests (390×844 viewport): the bottom-sheet board layout
+ * (design: MobileVariantA, RFC #399 PR 4) plus responsive lobby screens.
+ */
+import { test, expect } from '@playwright/test';
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.describe('Mobile layout', () => {
+  test('homepage stacks and keeps the Play CTA reachable', async ({ page }) => {
+    await page.goto('/');
+    const cta = page.getByRole('link', { name: /play online/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', '/lobby');
+    // No horizontal overflow
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
+  });
+
+  test('lobby stacks create form above open lobbies', async ({ page }) => {
+    await page.goto('/lobby');
+    await expect(page.getByRole('heading', { name: /create room/i })).toBeVisible();
+    await expect(page.getByLabel(/player name/i)).toBeVisible();
+  });
+
+  test('board uses the bottom sheet; tap-driven create works', async ({ page }) => {
+    await page.goto('/dev');
+    const sheet = page.locator('[data-testid="mobile-sheet"]');
+    await sheet.waitFor({ state: 'visible', timeout: 20000 });
+
+    // Contextual bar lives in the sheet; hand is collapsed by default.
+    await expect(sheet.locator('[data-testid="context-action"][data-mode="idle"]')).toBeVisible();
+    await expect(sheet.locator('[data-testid^="hand-card-"]')).toHaveCount(0);
+
+    // The handle expands the hand strip (and collapses it again).
+    await page.locator('[data-testid="mobile-sheet-handle"]').click();
+    await expect(sheet.locator('[data-testid^="hand-card-"]').first()).toBeVisible();
+    await page.locator('[data-testid="mobile-sheet-handle"]').click();
+    await expect(sheet.locator('[data-testid^="hand-card-"]')).toHaveCount(0);
+    await page.locator('[data-testid="mobile-sheet-handle"]').click();
+    await expect(sheet.locator('[data-testid^="hand-card-"]').first()).toBeVisible();
+
+    // Card-driven create still works on mobile: tap hand card → create mode.
+    await sheet.locator('[data-testid^="hand-card-"]').first().click();
+    await expect(page.locator('[data-testid="context-action"]')).toHaveAttribute(
+      'data-mode',
+      'createProject',
+    );
+    // Cancel returns to idle.
+    await page.locator('[data-testid="ca-cancel"]').click();
+    await expect(page.locator('[data-testid="context-action"]')).toHaveAttribute('data-mode', 'idle');
+  });
+});

--- a/packages/webapp/src/app/game/[matchID]/page.tsx
+++ b/packages/webapp/src/app/game/[matchID]/page.tsx
@@ -268,8 +268,8 @@ export default function GameRoomPage() {
   return (
     <main style={{ minHeight: '100vh' }}>
       <LobbyNav />
-      <div style={{ padding: '32px 64px', maxWidth: 1280, margin: '0 auto' }}>
-        <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 32, alignItems: 'start' }}>
+      <div className="page-pad">
+        <div className="grid-main-rail">
           <div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
               <h1 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 22, fontWeight: 800 }}>

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -351,3 +351,59 @@ button {
     var(--paper) 8px 16px
   );
 }
+
+/* ——— Responsive layout utilities (mobile breakpoint: 899px) ——— */
+.page-pad {
+  padding: 40px 64px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+/* Hero: text + composition side by side, stacks on mobile */
+.grid-hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 48px;
+  align-items: center;
+}
+
+/* Two even columns, stacks on mobile */
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+/* Wide + narrow rail (waiting room), stacks on mobile */
+.grid-main-rail {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 32px;
+  align-items: start;
+}
+
+/* Seat cards */
+.grid-seats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+@media (max-width: 899px) {
+  .page-pad {
+    padding: 20px;
+  }
+  .grid-hero,
+  .grid-2col,
+  .grid-main-rail {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+  .grid-seats {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+  .h-display {
+    font-size: 34px;
+  }
+}

--- a/packages/webapp/src/app/lobby/page.tsx
+++ b/packages/webapp/src/app/lobby/page.tsx
@@ -273,12 +273,12 @@ export default function LobbyPage() {
   return (
     <main style={{ minHeight: '100vh' }}>
       <LobbyNav />
-      <div style={{ padding: '40px 64px', maxWidth: 1280, margin: '0 auto' }}>
+      <div className="page-pad">
         <h1 style={{ display: 'flex', flexDirection: 'column', gap: 2, fontSize: 22, fontWeight: 800, marginBottom: 28 }}>
           開始一場遊戲 <span className="en-cap">Start a session</span>
         </h1>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, alignItems: 'start' }}>
+        <div className="grid-2col">
           {/* Create room */}
           <PaperCard padding={28} data-testid="create-room-card">
             <CardHeading icon="＋" iconBackground="var(--orange)" zh="開新房間" en="Create room" />

--- a/packages/webapp/src/app/page.tsx
+++ b/packages/webapp/src/app/page.tsx
@@ -24,17 +24,7 @@ export default function Home() {
   return (
     <main style={{ minHeight: '100vh' }}>
       <LobbyNav />
-      <div
-        style={{
-          padding: '48px 64px',
-          display: 'grid',
-          gridTemplateColumns: '1.1fr 0.9fr',
-          gap: 48,
-          alignItems: 'center',
-          maxWidth: 1280,
-          margin: '0 auto',
-        }}
-      >
+      <div className="page-pad grid-hero">
         <div>
           <div
             style={{

--- a/packages/webapp/src/components/BoardGame.tsx
+++ b/packages/webapp/src/components/BoardGame.tsx
@@ -18,7 +18,10 @@ import JobMarket from './board/JobMarket';
 import ContextAction from './board/ContextAction';
 import DiscardPanel from './board/DiscardPanel';
 import BoardProjectSlot from './board/BoardProjectSlot';
+import EventBanner from './board/EventBanner';
+import MobileSheet from './board/MobileSheet';
 import { ScorePanel, TurnOrderPanel } from './board/SidePanels';
+import { useIsMobile } from '@/lib/useIsMobile';
 
 const Board: React.FC<GameContext> = (gameContext) => {
   const { G, playerID, ctx } = gameContext;
@@ -38,6 +41,7 @@ const Board: React.FC<GameContext> = (gameContext) => {
     (outOfAP || G.table.actionPhaseDone);
 
   const idle = isMyTurn && currentAction === null && !showDiscardPanel && !gameover;
+  const isMobile = useIsMobile();
 
   // Idle tap on a board project → contribute; ownership picks the move.
   const handleProjectIdleTap = (slot: ProjectSlotState) => {
@@ -51,7 +55,118 @@ const Board: React.FC<GameContext> = (gameContext) => {
     );
   };
 
-  return (
+  // Shared between the desktop layout and the mobile bottom sheet.
+  const actionArea = isMyTurn ? (
+    showDiscardPanel ? (
+      <DiscardPanel gameContext={gameContext} />
+    ) : (
+      <ContextAction gameContext={gameContext} />
+    )
+  ) : (
+    playerID !== null && (
+      <div
+        data-testid="waiting-for-player-alert"
+        className="paper-card"
+        style={{
+          padding: '10px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 13,
+          color: 'var(--ink-soft)',
+        }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 999,
+            background: 'var(--orange)',
+            flexShrink: 0,
+          }}
+        />
+        等待 {playerNameMap[ctx.currentPlayer]} 行動中… Waiting for Player {ctx.currentPlayer}…
+      </div>
+    )
+  );
+
+  const projectsSection = (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, paddingLeft: 4 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{ fontWeight: 800, fontSize: 14 }}>專案區</span>
+          <span className="en-cap">Projects</span>
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--ink-mute)',
+            background: 'white',
+            border: '1.5px solid var(--paper-3)',
+            borderRadius: 999,
+            padding: '3px 10px',
+          }}
+        >
+          ⓘ 點桌上的專案來貢獻
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          gap: 14,
+          marginTop: 12,
+        }}
+      >
+        {G.table.projectBoard.map((slot) => (
+          <BoardProjectSlot
+            key={slot.id}
+            slot={slot}
+            playerID={playerID}
+            idle={idle}
+            onIdleTap={slot.card ? handleProjectIdleTap : undefined}
+          />
+        ))}
+      </div>
+    </div>
+  );
+
+  const jobMarket = <JobMarket gameContext={gameContext} idle={idle} discardActive={showDiscardPanel} />;
+
+  return isMobile ? (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'var(--paper)',
+        backgroundImage: 'radial-gradient(circle at 1px 1px, rgba(42,36,34,0.06) 1px, transparent 0)',
+        backgroundSize: '22px 22px',
+      }}
+    >
+      <GameHeader gameContext={gameContext} compact />
+      <div
+        style={{
+          flex: 1,
+          padding: '12px 12px 280px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+        }}
+      >
+        {G.table.eventSlot && <EventBanner event={G.table.eventSlot} />}
+        {projectsSection}
+        {jobMarket}
+        <ScorePanel gameContext={gameContext} />
+      </div>
+      <MobileSheet
+        action={actionArea}
+        hand={playerID !== null && <HandPanel gameContext={gameContext} idle={idle} layout="strip" />}
+      />
+
+      <GameOverDialog gameContext={gameContext} open={!!gameover && showGameOver} onClose={() => setShowGameOver(false)} />
+    </div>
+  ) : (
     <div
       style={{
         minHeight: '100vh',
@@ -79,80 +194,9 @@ const Board: React.FC<GameContext> = (gameContext) => {
 
         {/* CENTER — contextual action + projects + job market */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
-          {isMyTurn ? (
-            showDiscardPanel ? (
-              <DiscardPanel gameContext={gameContext} />
-            ) : (
-              <ContextAction gameContext={gameContext} />
-            )
-          ) : (
-            playerID !== null && (
-              <div
-                data-testid="waiting-for-player-alert"
-                className="paper-card"
-                style={{
-                  padding: '10px 16px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 10,
-                  fontSize: 13,
-                  color: 'var(--ink-soft)',
-                }}
-              >
-                <span
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: 999,
-                    background: 'var(--orange)',
-                    flexShrink: 0,
-                  }}
-                />
-                等待 {playerNameMap[ctx.currentPlayer]} 行動中… Waiting for Player {ctx.currentPlayer}…
-              </div>
-            )
-          )}
-
-          <div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, paddingLeft: 4 }}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <span style={{ fontWeight: 800, fontSize: 14 }}>專案區</span>
-                <span className="en-cap">Projects</span>
-              </div>
-              <span
-                style={{
-                  fontSize: 11,
-                  color: 'var(--ink-mute)',
-                  background: 'white',
-                  border: '1.5px solid var(--paper-3)',
-                  borderRadius: 999,
-                  padding: '3px 10px',
-                }}
-              >
-                ⓘ 點桌上的專案來貢獻
-              </span>
-            </div>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-                gap: 14,
-                marginTop: 12,
-              }}
-            >
-              {G.table.projectBoard.map((slot) => (
-                <BoardProjectSlot
-                  key={slot.id}
-                  slot={slot}
-                  playerID={playerID}
-                  idle={idle}
-                  onIdleTap={slot.card ? handleProjectIdleTap : undefined}
-                />
-              ))}
-            </div>
-          </div>
-
-          <JobMarket gameContext={gameContext} idle={idle} discardActive={showDiscardPanel} />
+          {actionArea}
+          {projectsSection}
+          {jobMarket}
         </div>
 
         {/* RIGHT — score + turn order */}
@@ -162,77 +206,90 @@ const Board: React.FC<GameContext> = (gameContext) => {
         </div>
       </div>
 
-      <Dialog open={!!gameover && showGameOver} onClose={() => setShowGameOver(false)} maxWidth="xs" fullWidth>
-        <DialogContent sx={{ p: 0 }}>
-          {gameover && (
-            <div style={{ padding: 24, background: 'var(--paper)', fontFamily: 'var(--font-zh)' }}>
-              <div style={{ textAlign: 'center' }}>
-                <div style={{ fontSize: 40 }}>🏆</div>
-                <h2 style={{ fontWeight: 900, fontSize: 22, color: 'var(--ink)' }}>遊戲結束</h2>
-                <div className="en-cap" style={{ marginTop: 2 }}>
-                  Game over
-                </div>
-                <div style={{ marginTop: 8, fontWeight: 700, color: 'var(--ink-soft)' }}>
-                  {gameover.winners.length > 1
-                    ? `平手：${gameover.winners.map((id) => playerNameMap[id]).join('、')}`
-                    : `${playerNameMap[gameover.winners[0]]} 獲勝！`}
-                </div>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 18 }}>
-                {Object.entries(ScoreBoardSelector.getAllPlayerPoints(G.table.scoreBoard))
-                  .sort(([, a], [, b]) => b - a)
-                  .map(([id, points]) => {
-                    const winner = gameover.winners.includes(id);
-                    return (
-                      <div
-                        key={id}
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 10,
-                          padding: '8px 12px',
-                          background: winner ? 'var(--orange-soft)' : 'white',
-                          border: winner ? '2px solid var(--orange)' : '1.5px solid var(--ink)',
-                          borderRadius: 12,
-                          boxShadow: '0 2px 0 var(--ink)',
-                        }}
-                      >
-                        <span
-                          style={{
-                            width: 26,
-                            height: 26,
-                            borderRadius: 999,
-                            background: PLAYER_COLORS[Number(id) % PLAYER_COLORS.length],
-                            color: 'white',
-                            border: '1.5px solid var(--ink)',
-                            display: 'grid',
-                            placeItems: 'center',
-                            fontFamily: 'var(--font-en)',
-                            fontWeight: 800,
-                            fontSize: 12,
-                          }}
-                        >
-                          {playerNameMap[id]?.[0]}
-                        </span>
-                        <span style={{ fontWeight: 700, flex: 1 }}>{playerNameMap[id]}</span>
-                        <strong style={{ fontFamily: 'var(--font-en)' }}>{points} VP</strong>
-                      </div>
-                    );
-                  })}
-              </div>
-              <StickerButton
-                onClick={() => setShowGameOver(false)}
-                style={{ width: '100%', marginTop: 18 }}
-              >
-                關閉 · Close
-              </StickerButton>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <GameOverDialog gameContext={gameContext} open={!!gameover && showGameOver} onClose={() => setShowGameOver(false)} />
     </div>
   );
 };
+
+function GameOverDialog({
+  gameContext,
+  open,
+  onClose,
+}: {
+  gameContext: GameContext;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const { G, ctx } = gameContext;
+  const gameover = ctx.gameover as { winners: string[] } | undefined;
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogContent sx={{ p: 0 }}>
+        {gameover && (
+          <div style={{ padding: 24, background: 'var(--paper)', fontFamily: 'var(--font-zh)' }}>
+            <div style={{ textAlign: 'center' }}>
+              <div style={{ fontSize: 40 }}>🏆</div>
+              <h2 style={{ fontWeight: 900, fontSize: 22, color: 'var(--ink)' }}>遊戲結束</h2>
+              <div className="en-cap" style={{ marginTop: 2 }}>
+                Game over
+              </div>
+              <div style={{ marginTop: 8, fontWeight: 700, color: 'var(--ink-soft)' }}>
+                {gameover.winners.length > 1
+                  ? `平手：${gameover.winners.map((id) => playerNameMap[id]).join('、')}`
+                  : `${playerNameMap[gameover.winners[0]]} 獲勝！`}
+              </div>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 18 }}>
+              {Object.entries(ScoreBoardSelector.getAllPlayerPoints(G.table.scoreBoard))
+                .sort(([, a], [, b]) => b - a)
+                .map(([id, points]) => {
+                  const winner = gameover.winners.includes(id);
+                  return (
+                    <div
+                      key={id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        padding: '8px 12px',
+                        background: winner ? 'var(--orange-soft)' : 'white',
+                        border: winner ? '2px solid var(--orange)' : '1.5px solid var(--ink)',
+                        borderRadius: 12,
+                        boxShadow: '0 2px 0 var(--ink)',
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 26,
+                          height: 26,
+                          borderRadius: 999,
+                          background: PLAYER_COLORS[Number(id) % PLAYER_COLORS.length],
+                          color: 'white',
+                          border: '1.5px solid var(--ink)',
+                          display: 'grid',
+                          placeItems: 'center',
+                          fontFamily: 'var(--font-en)',
+                          fontWeight: 800,
+                          fontSize: 12,
+                        }}
+                      >
+                        {playerNameMap[id]?.[0]}
+                      </span>
+                      <span style={{ fontWeight: 700, flex: 1 }}>{playerNameMap[id]}</span>
+                      <strong style={{ fontFamily: 'var(--font-en)' }}>{points} VP</strong>
+                    </div>
+                  );
+                })}
+            </div>
+            <StickerButton onClick={onClose} style={{ width: '100%', marginTop: 18 }}>
+              關閉 · Close
+            </StickerButton>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 type OwnProps = {
   isLocal: boolean;

--- a/packages/webapp/src/components/board/ContextAction.tsx
+++ b/packages/webapp/src/components/board/ContextAction.tsx
@@ -289,7 +289,8 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 14,
+        flexWrap: 'wrap',
+        gap: 12,
         background: 'white',
         border: '2px solid var(--ink)',
         borderRadius: 18,
@@ -315,7 +316,9 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
       >
         {copy.icon}
       </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
+      {/* flex-basis 180px: on narrow screens the text keeps a readable column
+          and the AP dots + buttons wrap to the next row instead of squeezing it */}
+      <div style={{ flex: '1 1 180px', minWidth: 0 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
           <strong style={{ fontSize: 15 }}>{copy.title}</strong>
           <span className="en-cap">{copy.en}</span>

--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -6,16 +6,23 @@ import { PlayersSelector } from '@/game/store/slice/players';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { playerNameMap } from '@/components/playerNameMap';
 
-/** Sticky table header: logo + per-player status chips (design: GameHeader). */
-export default function GameHeader({ gameContext }: { gameContext: GameContext }) {
+/** Sticky table header: logo + per-player status chips (design: GameHeader).
+ *  `compact` (mobile): chips scroll horizontally instead of wrapping. */
+export default function GameHeader({
+  gameContext,
+  compact = false,
+}: {
+  gameContext: GameContext;
+  compact?: boolean;
+}) {
   const { G, ctx, playerID } = gameContext;
   return (
     <div
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 14,
-        padding: '10px 20px',
+        gap: compact ? 8 : 14,
+        padding: compact ? '8px 12px' : '10px 20px',
         background: 'white',
         borderBottom: '2px solid var(--ink)',
         position: 'sticky',
@@ -23,8 +30,20 @@ export default function GameHeader({ gameContext }: { gameContext: GameContext }
         zIndex: 10,
       }}
     >
-      <Logo size="sm" />
-      <div style={{ display: 'flex', gap: 8, marginLeft: 'auto', alignItems: 'center', flexWrap: 'wrap' }}>
+      {!compact && <Logo size="sm" />}
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          marginLeft: compact ? 0 : 'auto',
+          alignItems: 'center',
+          flexWrap: compact ? 'nowrap' : 'wrap',
+          overflowX: compact ? 'auto' : 'visible',
+          minWidth: 0,
+          flex: compact ? 1 : undefined,
+          paddingTop: 8,
+        }}
+      >
         {Object.keys(G.players).map((id) => (
           <PlayerHeaderChip
             key={id}
@@ -38,8 +57,8 @@ export default function GameHeader({ gameContext }: { gameContext: GameContext }
           />
         ))}
       </div>
-      <Link href="/lobby" className="btn-sticker sm ghost" style={{ marginLeft: 12 }}>
-        離開 <span className="tag-en">Leave</span>
+      <Link href="/lobby" className="btn-sticker sm ghost" style={{ marginLeft: compact ? 4 : 12, flexShrink: 0 }}>
+        離開 {!compact && <span className="tag-en">Leave</span>}
       </Link>
     </div>
   );
@@ -78,6 +97,7 @@ function PlayerHeaderChip({
         borderRadius: 999,
         boxShadow: active ? '0 3px 0 var(--orange)' : '0 2px 0 var(--ink)',
         position: 'relative',
+        flexShrink: 0,
       }}
     >
       <span

--- a/packages/webapp/src/components/board/HandPanel.tsx
+++ b/packages/webapp/src/components/board/HandPanel.tsx
@@ -10,8 +10,19 @@ import {
 import EventBanner from './EventBanner';
 import ProjectCardFace from './ProjectCardFace';
 
-/** Left rail: your hand + this round's event (design: BoardVariantA left column). */
-export default function HandPanel({ gameContext, idle }: { gameContext: GameContext; idle: boolean }) {
+/**
+ * Your hand. `rail` = desktop left column with the event card below;
+ * `strip` = horizontal scroller inside the mobile bottom sheet.
+ */
+export default function HandPanel({
+  gameContext,
+  idle,
+  layout = 'rail',
+}: {
+  gameContext: GameContext;
+  idle: boolean;
+  layout?: 'rail' | 'strip';
+}) {
   const { G, playerID } = gameContext;
   const dispatch = useAppDispatch();
   const handInteractive = useAppSelector(isHandProjectCardsInteractive);
@@ -32,26 +43,43 @@ export default function HandPanel({ gameContext, idle }: { gameContext: GameCont
     }
   };
 
+  const strip = layout === 'strip';
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, overflowY: 'auto', paddingTop: 4 }}>
+    <div
+      style={
+        strip
+          ? { display: 'flex', flexDirection: 'column', gap: 8 }
+          : { display: 'flex', flexDirection: 'column', gap: 12, overflowY: 'auto', paddingTop: 4 }
+      }
+    >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <span style={{ fontWeight: 800, fontSize: 14 }}>你的手牌</span>
-          <span className="en-cap">Your hand</span>
+          <span style={{ fontWeight: 800, fontSize: strip ? 12 : 14 }}>你的手牌</span>
+          {!strip && <span className="en-cap">Your hand</span>}
         </div>
         <span className="sticker" style={{ marginLeft: 'auto' }}>
           {hand.length}
         </span>
       </div>
-      {hand.map((card) => (
-        <ProjectCardFace
-          key={card.id}
-          card={card}
-          data-testid={`hand-card-${card.id}`}
-          selected={handInteractive && !!selectedCards[card.id]}
-          onClick={idle || handInteractive ? () => handleTap(card.id) : undefined}
-        />
-      ))}
+      <div
+        style={
+          strip
+            ? { display: 'flex', gap: 10, overflowX: 'auto', paddingBottom: 4 }
+            : { display: 'flex', flexDirection: 'column', gap: 12 }
+        }
+      >
+        {hand.map((card) => (
+          <div key={card.id} style={strip ? { flexShrink: 0, width: 210 } : undefined}>
+            <ProjectCardFace
+              card={card}
+              data-testid={`hand-card-${card.id}`}
+              selected={handInteractive && !!selectedCards[card.id]}
+              onClick={idle || handInteractive ? () => handleTap(card.id) : undefined}
+            />
+          </div>
+        ))}
+      </div>
       {hand.length === 0 && (
         <div
           className="hatch"
@@ -68,7 +96,7 @@ export default function HandPanel({ gameContext, idle }: { gameContext: GameCont
         </div>
       )}
 
-      {event && (
+      {event && !strip && (
         <>
           <div className="dotted" style={{ margin: '8px 0' }} />
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>

--- a/packages/webapp/src/components/board/MobileSheet.tsx
+++ b/packages/webapp/src/components/board/MobileSheet.tsx
@@ -1,0 +1,73 @@
+import { ReactNode, useState } from 'react';
+
+/**
+ * Mobile bottom sheet (design: MobileVariantA) — pinned to the viewport
+ * bottom; the handle collapses/expands the hand strip so the board behind
+ * stays readable.
+ */
+export default function MobileSheet({
+  action,
+  hand,
+}: {
+  /** ContextAction / DiscardPanel / waiting note */
+  action: ReactNode;
+  /** HandPanel strip (players only) */
+  hand: ReactNode;
+}) {
+  // Collapsed by default: the contextual bar stays visible, the hand
+  // expands over the board like a drawer (capped, internally scrollable).
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div
+      data-testid="mobile-sheet"
+      data-expanded={expanded}
+      style={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 30,
+        background: 'white',
+        borderTop: '2px solid var(--ink)',
+        borderRadius: '22px 22px 0 0',
+        boxShadow: '0 -10px 30px -10px rgba(0,0,0,0.18)',
+        padding: '6px 14px 14px',
+        maxHeight: '70vh',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <button
+        type="button"
+        data-testid="mobile-sheet-handle"
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 2,
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          padding: '4px 0 6px',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            display: 'block',
+            width: 44,
+            height: 4,
+            background: 'var(--paper-3)',
+            borderRadius: 999,
+          }}
+        />
+        <span className="en-cap">{expanded ? '收合手牌 · Hide hand' : '展開手牌 · Show hand'}</span>
+      </button>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, overflowY: 'auto', minHeight: 0 }}>
+        {action}
+        {expanded && hand}
+      </div>
+    </div>
+  );
+}

--- a/packages/webapp/src/components/board/ProjectCardFace.tsx
+++ b/packages/webapp/src/components/board/ProjectCardFace.tsx
@@ -26,6 +26,7 @@ export default function ProjectCardFace({
     <div
       onClick={onClick}
       data-requirements={Object.keys(card.requirements).join(',')}
+      data-job-requirements={JSON.stringify(card.requirements)}
       {...rest}
       style={{
         position: 'relative',

--- a/packages/webapp/src/lib/useIsMobile.ts
+++ b/packages/webapp/src/lib/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(max-width: 899px)';
+
+function subscribe(onChange: () => void) {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+/** True below the 900px breakpoint. Client components only (SSR snapshot: false). */
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(QUERY).matches,
+    () => false,
+  );
+}


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Part 4 of 5 of the webapp UI redesign (RFC #399): the game board becomes playable on phones via a bottom-sheet layout (design MobileVariantA), and the lobby screens go responsive. Rebased on the evidence-gate main; verified against the new dual-server Playwright harness.

## Changes

- Mobile board layout below 900px (`useIsMobile`): single-column board with compact scrollable-chip header, plus a viewport-pinned bottom sheet — contextual action bar always visible, hand strip expands over the board via the handle (collapsed by default, capped at 70vh).
- `HandPanel` gains a `strip` layout; `GameHeader` a `compact` mode; `ContextAction` wraps on narrow screens; game-over dialog extracted for reuse by both layouts.
- Responsive utilities (`page-pad`, `grid-hero`, `grid-2col`, `grid-main-rail`, `grid-seats`, 899px breakpoint) replace fixed inline grids on home, lobby, and waiting room.
- New `e2e/mobile.spec.ts` (390×844); `game-flow.spec.ts` helpers de-flaked against deck randomness (四大自由 forced discard on last player's end-turn; market-aware create-combo selection).

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:** <!-- Required when "Evidence not applicable" is selected. -->

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Board is playable on a phone: pinned sheet keeps the contextual bar + AP visible while the board scrolls | Real 3-player online match (lobby → create → 2 joins → host start → `/game/[matchID]` over SocketIO), Alice at 390×844, her turn | [Live mobile board](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/03-live-board.png) · [DevView equivalent](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/02-mobile-board.png) |
| Card-driven actions work from the sheet: handle expands hand, tap card → create mode | Same live match: expand hand strip, tap first hand card, observe create prompt + selection ring + disabled confirm | [Live create mode](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/04-live-create.png) · [DevView equivalent](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/04-mobile-create.png) · `mobile.spec.ts` 3/3 ✓ |
| Lobby + waiting room stack correctly on mobile, no horizontal overflow | Same live match at 390×844: create form, then waiting room with seat grid; overflow asserted in spec | [Mobile lobby](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/01-live-lobby.png) · [Mobile waiting room](https://raw.githubusercontent.com/ocftw/open-star-ter-village/984191a7e82ebd7f7f01123da1a64f6757eb9679/02-live-waiting.png) · overflow check in `mobile.spec.ts` ✓ |
| Desktop board and full game interaction unaffected | Full Playwright suite (10 game-flow + 13 multiplayer + 3 mobile) against the new dual-server harness on the rebased branch | 26/26 ✓ (post-rebase run; previously 26/26 ×2 pre-rebase) |
| game-flow helpers no longer flake on deck randomness | 10 consecutive `game-flow.spec.ts` runs after fixing 四大自由 discard handling and market-aware create-combo selection | 10/10 clean runs (previously ~1-in-3 failures reproduced and diagnosed) |

## Risks and limitations

- The legacy "Room … / Connected as seat …" MUI page chrome around the live board is untouched and costs the most space on mobile — first item in PR 5.
- Mirror-of-refill remains single-select (noted in #402); PR 5 candidate.
