### PR TITLE
fix(ci): validate snapshot-only changes

### DIFF
--- a/.github/workflows/update-homepage-visual-baselines.yml
+++ b/.github/workflows/update-homepage-visual-baselines.yml
@@ -78,6 +78,12 @@ jobs:
         working-directory: homepage
         run: yarn build
 
+      - name: Record pre-generation worktree state
+        run: |
+          git status --porcelain=v1 -uall \
+            | grep -Ev '^.. homepage/e2e/__screenshots__/.*\.png$' \
+            > "$RUNNER_TEMP/pre-generation-status" || true
+
       - name: Regenerate all visual baselines
         working-directory: homepage
         run: yarn test:visual:update
@@ -93,10 +99,14 @@ jobs:
             exit 1
           fi
 
-          unexpected=$(git status --short | awk '{print $2}' | grep -Ev '^homepage/e2e/__screenshots__/.*\.png$' || true)
-          if [[ -n "$unexpected" ]]; then
-            echo "Snapshot generation changed unexpected files:"
-            echo "$unexpected"
+          git status --porcelain=v1 -uall \
+            | grep -Ev '^.. homepage/e2e/__screenshots__/.*\.png$' \
+            > "$RUNNER_TEMP/post-generation-status" || true
+
+          if ! diff -u \
+            "$RUNNER_TEMP/pre-generation-status" \
+            "$RUNNER_TEMP/post-generation-status"; then
+            echo "Snapshot generation changed files outside the baseline directory."
             exit 1
           fi
 


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Fix the manual homepage baseline updater so it distinguishes pre-existing install/build changes from files newly changed by snapshot generation. The first real run generated all 16 snapshots successfully but the old guard rejected an OS-specific Yarn cache file that already existed before Playwright ran.

## Changes

- Record detailed untracked worktree state immediately before snapshot generation.
- Compare the non-snapshot state after generation against that captured baseline.
- Keep the exactly-16 PNG check and explicit snapshot-only staging unchanged.

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:**

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Root cause reproduced | Run the updater against PR #408 on Ubuntu 24/Node 24 | [Run 29170292380](https://github.com/ocftw/open-star-ter-village/actions/runs/29170292380): all 16 Playwright cases passed; validation then rejected the pre-existing Linux SWC cache and collapsed snapshot directory |
| Guard syntax | Parse workflow YAML and check whitespace | Local YAML parse and git diff checks passed |

## Risks and limitations

The corrected workflow still commits only `homepage/e2e/__screenshots__` and still uses force-with-lease against the dispatch-time branch SHA. Runtime confirmation requires this fix on the default branch, after which PR #408 will rerun the action.

Refs #394