### PR TITLE
fix(webapp): unify lobby and game headers behind AppHeader shell (B-004)

### DIFF
--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { PlayerID } from 'boardgame.io';
-import { Logo, PLAYER_COLORS } from '@/components/design';
+import { AppHeader, PLAYER_COLORS } from '@/components/design';
 import { GameContext } from '@/components/GameContextHelpers';
 import { PlayersSelector } from '@/game/store/slice/players';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from '@/components/playerNameMap';
 
-/** Sticky table header: logo + per-player status chips (design: GameHeader).
+/** Sticky table header: shared app shell + per-player status chips (design: GameHeader).
  *  `compact` (mobile): chips scroll horizontally instead of wrapping. */
 export default function GameHeader({
   gameContext,
@@ -17,50 +17,43 @@ export default function GameHeader({
 }) {
   const { G, ctx, playerID, matchData } = gameContext;
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: compact ? 8 : 14,
-        padding: compact ? '8px 12px' : '10px 20px',
-        background: 'white',
-        borderBottom: '2px solid var(--ink)',
-        position: 'sticky',
-        top: 0,
-        zIndex: 10,
-      }}
-    >
-      {!compact && <Logo size="sm" />}
-      <div
-        style={{
-          display: 'flex',
-          gap: 8,
-          marginLeft: compact ? 0 : 'auto',
-          alignItems: 'center',
-          flexWrap: compact ? 'nowrap' : 'wrap',
-          overflowX: compact ? 'auto' : 'visible',
-          minWidth: 0,
-          flex: compact ? 1 : undefined,
-          paddingTop: 8,
-        }}
-      >
-        {Object.keys(G.players).map((id) => (
-          <PlayerHeaderChip
-            key={id}
-            id={id}
-            name={getPlayerName(matchData, id)}
-            workers={PlayersSelector.getNumWorkerTokens(G.players, id)}
-            actions={PlayersSelector.getNumActionTokens(G.players, id)}
-            score={ScoreBoardSelector.getPlayerPoints(G.table.scoreBoard, id)}
-            active={id === ctx.currentPlayer}
-            you={id === playerID}
-          />
-        ))}
-      </div>
-      <Link href="/lobby" className="btn-sticker sm ghost" style={{ marginLeft: compact ? 4 : 12, flexShrink: 0 }}>
-        離開 {!compact && <span className="tag-en">Leave</span>}
-      </Link>
-    </div>
+    <AppHeader
+      sticky
+      compact={compact}
+      right={
+        <>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              flexWrap: compact ? 'nowrap' : 'wrap',
+              overflowX: compact ? 'auto' : 'visible',
+              minWidth: 0,
+              flex: compact ? 1 : undefined,
+              // Headroom for the TURN badge that overflows the active chip.
+              paddingTop: 8,
+            }}
+          >
+            {Object.keys(G.players).map((id) => (
+              <PlayerHeaderChip
+                key={id}
+                id={id}
+                name={getPlayerName(matchData, id)}
+                workers={PlayersSelector.getNumWorkerTokens(G.players, id)}
+                actions={PlayersSelector.getNumActionTokens(G.players, id)}
+                score={ScoreBoardSelector.getPlayerPoints(G.table.scoreBoard, id)}
+                active={id === ctx.currentPlayer}
+                you={id === playerID}
+              />
+            ))}
+          </div>
+          <Link href="/lobby" className="btn-sticker sm ghost" style={{ flexShrink: 0 }}>
+            離開 {!compact && <span className="tag-en">Leave</span>}
+          </Link>
+        </>
+      }
+    />
   );
 }
 

--- a/packages/webapp/src/components/design/AppHeader.test.tsx
+++ b/packages/webapp/src/components/design/AppHeader.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import LobbyNav from '@/components/lobby/LobbyNav';
+import GameHeader from '@/components/board/GameHeader';
+import { GameContext } from '@/components/GameContextHelpers';
+
+const gameContext = {
+  G: {
+    players: {
+      '0': { token: { workers: 12, actions: 4 } },
+      '1': { token: { workers: 12, actions: 4 } },
+    },
+    table: { scoreBoard: { '0': 2, '1': 0 } },
+  },
+  ctx: { currentPlayer: '0' },
+  playerID: '0',
+  matchData: undefined,
+} as unknown as GameContext;
+
+const shellOf = (ui: React.ReactElement) => {
+  const { getByTestId, unmount } = render(ui);
+  const el = getByTestId('app-header');
+  const style = {
+    minHeight: el.style.minHeight,
+    padding: el.style.padding,
+    background: el.style.background,
+    borderBottom: el.style.borderBottom,
+  };
+  const logoLink = el.querySelector('a[aria-label="回首頁 Home"]');
+  const result = { style, hasLogoLink: !!logoLink, el };
+  return { ...result, unmount };
+};
+
+describe('shared application header shell', () => {
+  it('lobby and desktop game headers share the same shell values', () => {
+    const lobby = shellOf(<LobbyNav />);
+    const lobbyStyle = lobby.style;
+    const lobbyHasLogo = lobby.hasLogoLink;
+    lobby.unmount();
+
+    const game = shellOf(<GameHeader gameContext={gameContext} />);
+    expect(game.style).toEqual(lobbyStyle);
+    expect(lobbyHasLogo).toBe(true);
+    expect(game.hasLogoLink).toBe(true);
+  });
+
+  it('game header keeps sticky positioning without changing resting visuals', () => {
+    const lobby = shellOf(<LobbyNav />);
+    const lobbyStyle = lobby.style;
+    lobby.unmount();
+
+    const game = shellOf(<GameHeader gameContext={gameContext} />);
+    expect(game.el.style.position).toBe('sticky');
+    // Resting visual treatment (colors, divider, height) matches the lobby.
+    expect(game.style).toEqual(lobbyStyle);
+  });
+
+  it('game surface exposes player chips and Leave inside the shared shell', () => {
+    const { getByTestId, getByText } = render(<GameHeader gameContext={gameContext} />);
+    expect(getByTestId('player-status-Alice')).toBeTruthy();
+    expect(getByTestId('player-status-Bob')).toBeTruthy();
+    expect(getByText('離開')).toBeTruthy();
+  });
+
+  it('compact mobile variant keeps only the star tile so chips get the width', () => {
+    const compact = shellOf(<GameHeader gameContext={gameContext} compact />);
+    expect(compact.hasLogoLink).toBe(true);
+    expect(compact.el.textContent).not.toContain('開源星手村');
+    expect(compact.style.minHeight).toBe('52px');
+    expect(compact.style.background).toBe('var(--paper)');
+    expect(compact.style.borderBottom).toBe('1.5px solid var(--paper-3)');
+  });
+
+  it('desktop surfaces keep the full wordmark', () => {
+    const desktop = shellOf(<GameHeader gameContext={gameContext} />);
+    expect(desktop.el.textContent).toContain('開源星手村');
+  });
+});

--- a/packages/webapp/src/components/design/AppHeader.tsx
+++ b/packages/webapp/src/components/design/AppHeader.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Link from 'next/link';
+import Logo from './Logo';
+
+/**
+ * Shared application-header shell for lobby and game surfaces.
+ * Owns the brand block, bar height, background, padding, and divider so both
+ * surfaces read as the same shell; callers supply their right-side content.
+ * The lobby header is the visual source of truth.
+ */
+export default function AppHeader({
+  right,
+  sticky = false,
+  compact = false,
+}: {
+  right?: React.ReactNode;
+  sticky?: boolean;
+  compact?: boolean;
+}) {
+  return (
+    <header
+      data-testid="app-header"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: compact ? 8 : 14,
+        minHeight: compact ? 52 : 72,
+        padding: compact ? '0 12px' : '0 36px',
+        background: 'var(--paper)',
+        borderBottom: '1.5px solid var(--paper-3)',
+        ...(sticky && { position: 'sticky' as const, top: 0, zIndex: 10 }),
+      }}
+    >
+      <Link href="/" aria-label="回首頁 Home" style={{ flexShrink: 0 }}>
+        {/* Compact bars keep only the star tile so player chips get the width. */}
+        <Logo size={compact ? 'sm' : 'md'} iconOnly={compact} />
+      </Link>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          flex: 1,
+          minWidth: 0,
+          gap: compact ? 8 : 14,
+        }}
+      >
+        {right}
+      </div>
+    </header>
+  );
+}

--- a/packages/webapp/src/components/design/Logo.tsx
+++ b/packages/webapp/src/components/design/Logo.tsx
@@ -1,5 +1,7 @@
 type LogoProps = {
   size?: 'sm' | 'md' | 'lg';
+  /** Render only the star tile — for bars too narrow for the wordmark. */
+  iconOnly?: boolean;
 };
 
 const STAR_BOX: Record<NonNullable<LogoProps['size']>, number> = {
@@ -8,7 +10,14 @@ const STAR_BOX: Record<NonNullable<LogoProps['size']>, number> = {
   lg: 44,
 };
 
-export default function Logo({ size = 'md' }: LogoProps) {
+// Radius scales with the tile so small sizes stay a rounded square, not a circle.
+const STAR_RADIUS: Record<NonNullable<LogoProps['size']>, number> = {
+  sm: 10,
+  md: 12,
+  lg: 12,
+};
+
+export default function Logo({ size = 'md', iconOnly = false }: LogoProps) {
   const box = STAR_BOX[size];
   const big = size === 'lg';
   return (
@@ -19,7 +28,7 @@ export default function Logo({ size = 'md' }: LogoProps) {
           height: box,
           background: 'var(--orange)',
           border: '2px solid var(--ink)',
-          borderRadius: 12,
+          borderRadius: STAR_RADIUS[size],
           display: 'grid',
           placeItems: 'center',
           boxShadow: '0 3px 0 var(--ink)',
@@ -39,30 +48,32 @@ export default function Logo({ size = 'md' }: LogoProps) {
           ★
         </span>
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
-        <div
-          style={{
-            fontFamily: 'var(--font-zh)',
-            fontWeight: 900,
-            fontSize: big ? 22 : 16,
-            color: 'var(--ink)',
-          }}
-        >
-          開源星手村
+      {!iconOnly && (
+        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-zh)',
+              fontWeight: 900,
+              fontSize: big ? 22 : 16,
+              color: 'var(--ink)',
+            }}
+          >
+            開源星手村
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--font-en)',
+              fontSize: big ? 11 : 9,
+              color: 'var(--ink-mute)',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              marginTop: 2,
+            }}
+          >
+            Open StarTer Village
+          </div>
         </div>
-        <div
-          style={{
-            fontFamily: 'var(--font-en)',
-            fontSize: big ? 11 : 9,
-            color: 'var(--ink-mute)',
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-            marginTop: 2,
-          }}
-        >
-          Open StarTer Village
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/packages/webapp/src/components/design/index.ts
+++ b/packages/webapp/src/components/design/index.ts
@@ -1,3 +1,4 @@
+export { default as AppHeader } from './AppHeader';
 export { default as Logo } from './Logo';
 export { default as StickerButton } from './StickerButton';
 export { default as PaperCard } from './PaperCard';

--- a/packages/webapp/src/components/lobby/LobbyNav.tsx
+++ b/packages/webapp/src/components/lobby/LobbyNav.tsx
@@ -1,41 +1,31 @@
-import Link from 'next/link';
-import { Logo } from '@/components/design';
+import { AppHeader } from '@/components/design';
 
 const HOMEPAGE_URL = 'https://openstartervillage.ocf.tw';
 const GITHUB_URL = 'https://github.com/ocftw/open-star-ter-village';
 
 export default function LobbyNav() {
   return (
-    <nav
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '18px 36px',
-        borderBottom: '1.5px solid var(--paper-3)',
-      }}
-    >
-      <Link href="/" aria-label="回首頁 Home">
-        <Logo />
-      </Link>
-      <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
-        <a
-          href={HOMEPAGE_URL}
-          target="_blank"
-          rel="noreferrer"
-          style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
-        >
-          規則 <span className="en-cap">Rules</span>
-        </a>
-        <a
-          href={GITHUB_URL}
-          target="_blank"
-          rel="noreferrer"
-          style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
-        >
-          GitHub
-        </a>
-      </div>
-    </nav>
+    <AppHeader
+      right={
+        <nav style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+          <a
+            href={HOMEPAGE_URL}
+            target="_blank"
+            rel="noreferrer"
+            style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
+          >
+            規則 <span className="en-cap">Rules</span>
+          </a>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}
+          >
+            GitHub
+          </a>
+        </nav>
+      }
+    />
   );
 }


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Fixes B-004 from #406: the in-game header used a different height, background, logo size, and divider than the lobby header, so entering a game felt like switching application shells.

## Changes

- New shared `AppHeader` shell (`src/components/design/AppHeader.tsx`) owning the linked brand block, bar height (72px desktop / 52px compact), paper background, horizontal padding, `1.5px var(--paper-3)` divider, and optional sticky positioning. Lobby values are the source of truth.
- `LobbyNav` reduced to shell + right-side lobby links; `GameHeader` reduced to shell + player chips + Leave (sticky retained). No duplicated shell styling remains in either component.
- Compact mobile game header keeps only the star tile (same brand asset/colors, rounded-square at every size) so player chips get the width; chips scroll horizontally without overflow.
- Component tests assert lobby and desktop game shells are value-identical, sticky does not change resting visuals, chips/Leave render, and the compact variant metrics.

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:** —

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Lobby and desktop game headers share the shell | Dev server at 1280px: `/lobby` and in-game board (offline dev harness) | Computed styles both measure `height: 72`, `background: oklch(0.985 0.012 75)`, `borderBottom: 1.5px oklch(0.93 0.022 75)`; only difference is `position: sticky` on the game header (intended) |
| No visible shell change lobby → game | Same session navigation | Same measured bar height/colors/divider before and after; logo asset and size (md) identical |
| Compact mobile variant | 375×812 viewport on the in-game board | Brand block present (sm logo, same colors), player chip strip scrolls horizontally, Leave visible, no horizontal page overflow |
| Behavior/tests | `yarn workspace @open-star-ter-village/webapp test` + `yarn lint` | 58/58 tests pass incl. new `AppHeader.test.tsx`; ESLint clean |

### Screenshots (user view)

Lobby and in-game headers now share the same shell (logo, height, paper background, divider):

![Lobby header](https://github.com/user-attachments/assets/e76525d1-2ecf-4f3c-b21a-081225235c52)
![Game header](https://github.com/user-attachments/assets/96edad75-2def-4d08-9dbe-e27f81cf5646)

Compact mobile game header keeps only the star tile, leaving the width to the player chips and Leave:

![Compact mobile game header](https://github.com/user-attachments/assets/6c2520bb-c210-43f7-a98c-9180e0c0cd90)

## Risks and limitations

Stacked on #410 (needs the component-test tooling introduced there); GitHub will retarget to `main` when #410 merges. Desktop game header is ~4px taller than before by design (matches lobby).

Part of #406 (B-004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



