### PR TITLE
fix(webapp): exit-choice dialog, leave-terminates, lobby re-entry and spectate

### DIFF
--- a/packages/webapp/e2e/mobile.spec.ts
+++ b/packages/webapp/e2e/mobile.spec.ts
@@ -52,4 +52,18 @@ test.describe('Mobile layout', () => {
     await page.locator('[data-testid="ca-cancel"]').click();
     await expect(page.locator('[data-testid="context-action"]')).toHaveAttribute('data-mode', 'idle');
   });
+
+  test('compact header ⋯ menu opens the exit-choice dialog (#420)', async ({ page }) => {
+    await page.goto('/dev');
+    await page.locator('[data-testid="mobile-sheet"]').waitFor({ state: 'visible', timeout: 20000 });
+
+    await page.locator('[data-testid="header-menu"]').first().click();
+    await page.locator('[data-testid="menu-leave"]').first().click();
+    await expect(page.locator('[data-testid="exit-dialog"]')).toBeVisible();
+
+    // Cancel closes safely with no navigation or state change.
+    await page.locator('[data-testid="exit-cancel"]').click();
+    await expect(page.locator('[data-testid="exit-dialog"]')).toHaveCount(0);
+    await expect(page).toHaveURL(/\/dev/);
+  });
 });

--- a/packages/webapp/e2e/multiplayer.spec.ts
+++ b/packages/webapp/e2e/multiplayer.spec.ts
@@ -133,6 +133,54 @@ test.describe('Full multiplayer flow', () => {
     await expect(observerPage.locator('[data-testid="context-action"]')).toHaveCount(0);
     await observer.close();
   });
+
+  test('Lobby offers 觀戰 for an in-progress room without a seat (#421)', async () => {
+    const visitor = await browser.newContext();
+    const visitorPage = await visitor.newPage();
+    await visitorPage.goto('/lobby');
+    const row = visitorPage.locator(`[data-testid="match-row-${matchID}"]`);
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row.locator('[data-testid="match-spectate"]')).toBeVisible();
+    await row.locator('[data-testid="match-spectate"]').click();
+    await visitorPage.waitForURL(`**/game/${matchID}`, { timeout: 15_000 });
+    await expect(visitorPage.locator('[data-testid="observer-mode-banner"]')).toBeVisible({ timeout: 15_000 });
+    await visitor.close();
+  });
+
+  test('Alice leaves keeping her seat and returns via 回到桌子 (#420 + #421)', async () => {
+    // Leave goes through the explicit choice dialog — no immediate navigation.
+    await alicePage.locator('[data-testid="header-leave"]').click();
+    await expect(alicePage.locator('[data-testid="exit-dialog"]')).toBeVisible();
+    await expect(alicePage).toHaveURL(new RegExp(`/game/${matchID}`));
+
+    await alicePage.locator('[data-testid="exit-keep-seat"]').click();
+    await alicePage.waitForURL(/\/lobby/, { timeout: 15_000 });
+
+    // Her room offers 回到桌子, not Join.
+    const row = alicePage.locator(`[data-testid="match-row-${matchID}"]`);
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row.locator('[data-testid="match-return"]')).toBeVisible();
+    await row.locator('[data-testid="match-return"]').click();
+    await alicePage.waitForURL(new RegExp(`/game/${matchID}`), { timeout: 15_000 });
+
+    // Same seat resumed — board with her controls, not observer mode.
+    await expect(alicePage.locator('[data-testid^="player-status-"]').first()).toBeVisible({ timeout: 20_000 });
+    await expect(alicePage.locator('[data-testid="observer-mode-banner"]')).toHaveCount(0);
+  });
+
+  test('Bob releases his seat — the match terminates for the table (#420)', async () => {
+    await bobPage.locator('[data-testid="header-leave"]').click();
+    await expect(bobPage.locator('[data-testid="exit-dialog"]')).toBeVisible();
+    await bobPage.locator('[data-testid="exit-leave-seat"]').click();
+    await bobPage.waitForURL(/\/lobby/, { timeout: 15_000 });
+
+    // Remaining players see the terminated notice over a blocked board.
+    await expect(alicePage.locator('[data-testid="match-terminated-overlay"]')).toBeVisible({ timeout: 20_000 });
+
+    // The room disappears from the active lobby list.
+    await bobPage.getByRole('button', { name: /重新整理/ }).click();
+    await expect(bobPage.locator(`[data-testid="match-row-${matchID}"]`)).toHaveCount(0, { timeout: 15_000 });
+  });
 });
 
 test.describe('Game room edge cases', () => {

--- a/packages/webapp/jest.config.js
+++ b/packages/webapp/jest.config.js
@@ -2,6 +2,7 @@
 const config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/packages/webapp/jest.setup.ts
+++ b/packages/webapp/jest.setup.ts
@@ -1,12 +1,11 @@
 // jsdom does not implement HTMLDialogElement.showModal()/close(), which the
-// bespoke design/Modal uses. Shim just enough for component tests: reflect
-// the open state and fire the close event Modal listens to.
+// bespoke design/Modal uses. Shim just enough for component tests to reflect
+// the open state.
 if (typeof HTMLDialogElement !== 'undefined' && !HTMLDialogElement.prototype.showModal) {
   HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
     this.setAttribute('open', '');
   };
   HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
     this.removeAttribute('open');
-    this.dispatchEvent(new Event('close'));
   };
 }

--- a/packages/webapp/jest.setup.ts
+++ b/packages/webapp/jest.setup.ts
@@ -1,0 +1,12 @@
+// jsdom does not implement HTMLDialogElement.showModal()/close(), which the
+// bespoke design/Modal uses. Shim just enough for component tests: reflect
+// the open state and fire the close event Modal listens to.
+if (typeof HTMLDialogElement !== 'undefined' && !HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+}

--- a/packages/webapp/src/app/game/[matchID]/page.tsx
+++ b/packages/webapp/src/app/game/[matchID]/page.tsx
@@ -26,6 +26,46 @@ import {
 
 const MATCH_EXPIRED_MESSAGE = '房間不存在或已過期 · Match not found or expired';
 
+/** Full-screen non-dismissible notice: a player released their seat, ending the match (#420). */
+function MatchTerminatedOverlay() {
+  return (
+    <div
+      data-testid="match-terminated-overlay"
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="遊戲已終止"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1400,
+        background: 'rgba(42, 36, 34, 0.55)',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 20,
+      }}
+    >
+      <div
+        className="paper-card"
+        style={{ padding: 26, maxWidth: 420, width: '100%', textAlign: 'center', background: 'var(--paper)' }}
+      >
+        <div aria-hidden style={{ fontSize: 36 }}>🚪</div>
+        <strong style={{ display: 'block', fontSize: 18, marginTop: 8, color: 'var(--ink)' }}>
+          有玩家離席，遊戲已終止
+        </strong>
+        <div className="en-cap" style={{ marginTop: 4 }}>
+          A player left their seat — this game has ended
+        </div>
+        <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.55, margin: '10px 0 18px' }}>
+          這局不會計算勝負。回到大廳開新的一局吧。
+        </p>
+        <Link href="/lobby" className="btn-sticker" style={{ width: '100%' }}>
+          回大廳 <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Back to lobby</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 export default function GameRoomPage() {
   const params = useParams<{ matchID: string }>();
   const router = useRouter();
@@ -111,13 +151,19 @@ export default function GameRoomPage() {
     ? match.players.every((player) => !player.name?.trim() || player.isConnected === false)
     : false;
   const isHost = credentials?.playerID === '0';
-  const isFinished = match ? match.gameover !== undefined : false;
+  // A vacated seat in a started match means someone chose 離開座位 — the
+  // game is terminated for everyone (#420). Detected from authoritative
+  // lobby metadata (the socket does not push metadata changes mid-game).
+  const isTerminated =
+    Boolean(match) && hasStarted && match!.players.some((player) => !hasPlayerName(player));
   const shouldShowBoard = Boolean(match) && allSeatsFilled && hasStarted && !isExpired;
   const isMutating = isStarting || isLeaving || isRefreshing;
 
-  // Keep polling after game over so a purged room switches to the expired
-  // state instead of letting the socket silently re-create fresh match state.
-  usePolling(pollMatch, 3_000, (!shouldShowBoard || isFinished) && !isExpired);
+  // Poll for the whole room lifetime (not just the waiting room): mid-game it
+  // detects leave-termination, and after game over it detects the TTL purge so
+  // the page switches to the expired state instead of letting the socket
+  // silently re-create fresh match state.
+  usePolling(pollMatch, 3_000, !isExpired);
 
   const handleLeaveMatch = async () => {
     if (!credentials) {
@@ -248,6 +294,17 @@ export default function GameRoomPage() {
           credentials={credentials?.credential}
           numPlayers={match.players.length}
         />
+      </main>
+    );
+  }
+
+  if (match && isTerminated) {
+    // A seat was released mid-game (#420): the board unmounts (the vacated
+    // seat empties allSeatsFilled) and every remaining browser lands here.
+    return (
+      <main>
+        <LobbyNav />
+        <MatchTerminatedOverlay />
       </main>
     );
   }

--- a/packages/webapp/src/app/game/[matchID]/page.tsx
+++ b/packages/webapp/src/app/game/[matchID]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { Alert, Snackbar } from '@mui/material';
 import Boardgame from '@/components/BoardGame';
-import { StickerButton } from '@/components/design';
+import { Modal, StickerButton } from '@/components/design';
 import LobbyNav from '@/components/lobby/LobbyNav';
 import Note from '@/components/lobby/Note';
 import SeatCard from '@/components/lobby/SeatCard';
@@ -29,25 +29,14 @@ const MATCH_EXPIRED_MESSAGE = '房間不存在或已過期 · Match not found or
 /** Full-screen non-dismissible notice: a player released their seat, ending the match (#420). */
 function MatchTerminatedOverlay() {
   return (
-    <div
-      data-testid="match-terminated-overlay"
+    <Modal
+      open
+      ariaLabel="遊戲已終止"
       role="alertdialog"
-      aria-modal="true"
-      aria-label="遊戲已終止"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 1400,
-        background: 'rgba(42, 36, 34, 0.55)',
-        display: 'grid',
-        placeItems: 'center',
-        padding: 20,
-      }}
+      width="min(420px, 100%)"
+      dataTestid="match-terminated-overlay"
     >
-      <div
-        className="paper-card"
-        style={{ padding: 26, maxWidth: 420, width: '100%', textAlign: 'center', background: 'var(--paper)' }}
-      >
+      <div style={{ textAlign: 'center' }}>
         <div aria-hidden style={{ fontSize: 36 }}>🚪</div>
         <strong style={{ display: 'block', fontSize: 18, marginTop: 8, color: 'var(--ink)' }}>
           有玩家離席，遊戲已終止
@@ -62,7 +51,7 @@ function MatchTerminatedOverlay() {
           回大廳 <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Back to lobby</span>
         </Link>
       </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -231,21 +231,6 @@ button {
   overflow-y: auto;
   padding: 22px;
 }
-
-/* TRANSITIONAL: same sticker shell for the remaining MUI Dialog
-   (GameOverDialog in BoardGame.tsx). Delete together with the last MUI
-   Dialog — MUI is slated for removal. The descendant selectors outrank
-   MUI's runtime-injected emotion classes without !important. */
-.MuiDialog-root .MuiDialog-paper {
-  background: var(--paper);
-  border: 2px solid var(--ink);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sticker);
-}
-.MuiDialog-root .MuiBackdrop-root {
-  background: rgba(42, 36, 34, 0.4);
-}
-
 /* Headline */
 .h-display {
   font-family: var(--font-zh);

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -208,6 +208,20 @@ button {
   box-shadow: var(--shadow-sticker);
 }
 
+/* MUI Dialog shell (ExitDialog, GameOverDialog) — match the prototype's
+   .modal sticker panel: paper ground, 2px ink border, 22px corner, offset
+   sticker shadow over a warm ink-tinted backdrop. The descendant selectors
+   outrank MUI's runtime-injected emotion classes without !important. */
+.MuiDialog-root .MuiDialog-paper {
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sticker);
+}
+.MuiDialog-root .MuiBackdrop-root {
+  background: rgba(42, 36, 34, 0.4);
+}
+
 /* Headline */
 .h-display {
   font-family: var(--font-zh);

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -392,3 +392,46 @@ button {
     transform: scale(1.18);
   }
 }
+
+/* Icon button + menu items (design: icon-btn / menu-item) — the compact game
+   header's ⋯ menu and other square tap targets. 44px minimum touch size. */
+.icon-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 2px solid var(--ink);
+  background: white;
+  box-shadow: 0 2px 0 var(--ink);
+  display: grid;
+  place-items: center;
+  font-size: 17px;
+  cursor: pointer;
+  transition: transform 0.08s;
+}
+.icon-btn:hover {
+  transform: translateY(1px);
+  box-shadow: 0 1px 0 var(--ink);
+}
+.icon-btn[data-on='true'] {
+  background: var(--orange-soft);
+  border-color: var(--orange-deep);
+}
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: none;
+  background: none;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  text-align: left;
+  color: var(--ink);
+  cursor: pointer;
+}
+.menu-item:hover {
+  background: var(--paper-2);
+}

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -208,10 +208,34 @@ button {
   box-shadow: var(--shadow-sticker);
 }
 
-/* MUI Dialog shell (ExitDialog, GameOverDialog) — match the prototype's
-   .modal sticker panel: paper ground, 2px ink border, 22px corner, offset
-   sticker shadow over a warm ink-tinted backdrop. The descendant selectors
-   outrank MUI's runtime-injected emotion classes without !important. */
+/* Bespoke modal overlay — the prototype's .modal sticker panel: paper
+   ground, 2px ink border, 22px corner, offset sticker shadow over a warm
+   ink-tinted backdrop. New dialogs use these classes; MUI is not used in
+   new components. */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(42, 36, 34, 0.4);
+  z-index: 300;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+.modal {
+  background: var(--paper);
+  border: 2px solid var(--ink);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sticker);
+  width: min(560px, 100%);
+  max-height: 88vh;
+  overflow-y: auto;
+  padding: 22px;
+}
+
+/* TRANSITIONAL: same sticker shell for the remaining MUI Dialog
+   (GameOverDialog in BoardGame.tsx). Delete together with the last MUI
+   Dialog — MUI is slated for removal. The descendant selectors outrank
+   MUI's runtime-injected emotion classes without !important. */
 .MuiDialog-root .MuiDialog-paper {
   background: var(--paper);
   border: 2px solid var(--ink);

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -208,28 +208,31 @@ button {
   box-shadow: var(--shadow-sticker);
 }
 
-/* Bespoke modal overlay — the prototype's .modal sticker panel: paper
-   ground, 2px ink border, 22px corner, offset sticker shadow over a warm
-   ink-tinted backdrop. New dialogs use these classes; MUI is not used in
-   new components. */
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(42, 36, 34, 0.4);
-  z-index: 300;
-  display: grid;
-  place-items: center;
-  padding: 20px;
-}
+/* Bespoke modal — the prototype's .modal sticker panel on a native <dialog>
+   (design/Modal.tsx): paper ground, 2px ink border, 22px corner, offset
+   sticker shadow over a warm ink-tinted ::backdrop. MUI is not used in new
+   components. */
 .modal {
+  /* margin:auto restores centering that the global `* { margin: 0 }` reset
+     strips from the UA :modal default (inset:0 + margin:auto). */
+  margin: auto;
   background: var(--paper);
   border: 2px solid var(--ink);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sticker);
   width: min(560px, 100%);
+  max-width: calc(100vw - 40px);
   max-height: 88vh;
   overflow-y: auto;
   padding: 22px;
+  color: var(--ink);
+}
+.modal::backdrop {
+  background: rgba(42, 36, 34, 0.4);
+}
+/* Native showModal() does not lock page scroll. */
+body:has(.modal[open]) {
+  overflow: hidden;
 }
 /* Headline */
 .h-display {
@@ -434,10 +437,6 @@ button {
 .icon-btn:hover {
   transform: translateY(1px);
   box-shadow: 0 1px 0 var(--ink);
-}
-.icon-btn[data-on='true'] {
-  background: var(--orange-soft);
-  border-color: var(--orange-deep);
 }
 .menu-item {
   display: flex;

--- a/packages/webapp/src/app/lobby/page.tsx
+++ b/packages/webapp/src/app/lobby/page.tsx
@@ -282,8 +282,7 @@ export default function LobbyPage() {
                     joining={joiningMatchID === match.matchID}
                     busy={joiningMatchID !== null || isCreating}
                     onJoin={() => void handleJoinMatch(match.matchID)}
-                    onReturn={() => router.push(`/game/${match.matchID}`)}
-                    onSpectate={() => router.push(`/game/${match.matchID}`)}
+                    onOpen={() => router.push(`/game/${match.matchID}`)}
                   />
                 ))}
               </div>

--- a/packages/webapp/src/app/lobby/page.tsx
+++ b/packages/webapp/src/app/lobby/page.tsx
@@ -6,6 +6,7 @@ import { Alert, Snackbar } from '@mui/material';
 import { PaperCard, StickerButton } from '@/components/design';
 import Field from '@/components/lobby/Field';
 import LobbyNav from '@/components/lobby/LobbyNav';
+import MatchRow from '@/components/lobby/MatchRow';
 import Note from '@/components/lobby/Note';
 import Segmented from '@/components/lobby/Segmented';
 import { loadCredentials, saveCredentials, type MatchCredentials } from '@/lib/matchCredentials';
@@ -26,13 +27,6 @@ const PLAYER_COUNT_OPTIONS = [3, 4, 5, 6] as const;
 function isValidPlayerName(value: string): boolean {
   const trimmedValue = value.trim();
   return trimmedValue.length >= 1 && trimmedValue.length <= 20;
-}
-
-function formatDate(timestamp: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(timestamp);
 }
 
 function CardHeading({
@@ -74,91 +68,12 @@ function CardHeading({
   );
 }
 
-function MatchRow({
-  match,
-  seatsFilled,
-  totalSeats,
-  status,
-  joining,
-  disabled,
-  onJoin,
-}: {
-  match: VisibleMatch['match'];
-  seatsFilled: number;
-  totalSeats: number;
-  status: string;
-  joining: boolean;
-  disabled: boolean;
-  onJoin: () => void;
-}) {
-  return (
-    <div
-      data-testid={`match-row-${match.matchID}`}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '10px 14px',
-        background: 'white',
-        border: '1.5px solid var(--ink)',
-        borderRadius: 12,
-        boxShadow: '0 2px 0 var(--ink)',
-      }}
-    >
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 12,
-            fontWeight: 700,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {match.matchID}
-        </div>
-        <div style={{ fontSize: 11, color: 'var(--ink-mute)', marginTop: 2 }}>
-          {formatDate(match.createdAt)} · {status}
-        </div>
-      </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
-        {Array.from({ length: totalSeats }).map((_, i) => (
-          <span
-            key={i}
-            style={{
-              width: 16,
-              height: 16,
-              borderRadius: 999,
-              background: i < seatsFilled ? 'var(--orange)' : 'white',
-              border: '1.5px solid var(--ink)',
-            }}
-          />
-        ))}
-        <span
-          style={{
-            marginLeft: 4,
-            fontSize: 11,
-            fontWeight: 700,
-            color: 'var(--ink-soft)',
-            fontFamily: 'var(--font-en)',
-          }}
-        >
-          {seatsFilled}/{totalSeats}
-        </span>
-      </div>
-      <StickerButton variant="teal" size="sm" onClick={onJoin} disabled={disabled}>
-        {joining ? '加入中… · Joining' : '加入 · Join'}
-      </StickerButton>
-    </div>
-  );
-}
-
 export default function LobbyPage() {
   const router = useRouter();
   const [playerName, setPlayerName] = React.useState('');
   const [numPlayers, setNumPlayers] = React.useState<number>(3);
   const [matches, setMatches] = React.useState<VisibleMatch[]>([]);
+  const [mySeatMatchIDs, setMySeatMatchIDs] = React.useState<Record<string, boolean>>({});
   const [loadError, setLoadError] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
   const [isCreating, setIsCreating] = React.useState(false);
@@ -173,6 +88,16 @@ export default function LobbyPage() {
     try {
       const nextMatches = await listPublicMatches();
       setMatches(nextMatches);
+      // Rooms this browser still holds a seat credential for get 回到桌子
+      // instead of Join (#421). Validity is re-checked by the room page —
+      // never inferred from display names.
+      setMySeatMatchIDs(
+        Object.fromEntries(
+          nextMatches
+            .filter(({ match }) => loadCredentials(match.matchID) !== null)
+            .map(({ match }) => [match.matchID, true]),
+        ),
+      );
       setLoadError(false);
     } catch (error) {
       if (!silent) {
@@ -353,9 +278,12 @@ export default function LobbyPage() {
                     seatsFilled={seatsFilled}
                     totalSeats={totalSeats}
                     status={status}
+                    hasSeat={Boolean(mySeatMatchIDs[match.matchID])}
                     joining={joiningMatchID === match.matchID}
-                    disabled={status !== 'Waiting' || joiningMatchID !== null || isCreating}
+                    busy={joiningMatchID !== null || isCreating}
                     onJoin={() => void handleJoinMatch(match.matchID)}
+                    onReturn={() => router.push(`/game/${match.matchID}`)}
+                    onSpectate={() => router.push(`/game/${match.matchID}`)}
                   />
                 ))}
               </div>

--- a/packages/webapp/src/components/BoardGame.tsx
+++ b/packages/webapp/src/components/BoardGame.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { useRouter } from 'next/navigation';
 import { Game } from 'boardgame.io';
 import { GameState, ProjectSlotState } from '@/game';
-import { Dialog, DialogContent } from '@mui/material';
 import { GameContext } from './GameContextHelpers';
 import { GAME_NAME, GAME_SERVER_URL, lobbyClient } from '@/lib/lobbyClient';
 import { getLobbyErrorMessage, joinRoom } from '@/app/lobby/actions';
@@ -23,7 +22,7 @@ import { getSelectedProjectSlots } from '@/lib/reducers/projectSlotSlice';
 import { JobSlotsSelector } from '@/game/store/slice/jobSlots';
 import { RuleSelector } from '@/game/store/slice/rule';
 import { ProfessionPicker, getEligibleTargetJobNames } from './board/professionPicker';
-import { PLAYER_COLORS, StickerButton } from '@/components/design';
+import { Modal, PLAYER_COLORS, StickerButton } from '@/components/design';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from './playerNameMap';
 import GameHeader from './board/GameHeader';
@@ -333,11 +332,10 @@ export function GameOverDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogContent sx={{ p: 0 }}>
-        {gameover && (
-          <div style={{ padding: 24, background: 'var(--paper)', fontFamily: 'var(--font-zh)' }}>
-            <div style={{ textAlign: 'center' }}>
+    <Modal open={open} onClose={onClose} ariaLabel="遊戲結束" width="min(440px, 100%)">
+      {gameover && (
+        <div>
+          <div style={{ textAlign: 'center' }}>
               <div style={{ fontSize: 40 }}>🏆</div>
               <h2 style={{ fontWeight: 900, fontSize: 22, color: 'var(--ink)' }}>遊戲結束</h2>
               <div className="en-cap" style={{ marginTop: 2 }}>
@@ -424,8 +422,7 @@ export function GameOverDialog({
             </StickerButton>
           </div>
         )}
-      </DialogContent>
-    </Dialog>
+    </Modal>
   );
 }
 

--- a/packages/webapp/src/components/board/ExitDialog.test.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.test.tsx
@@ -32,7 +32,9 @@ describe('ExitDialog (#420)', () => {
   });
 
   it('offers the three explicit choices and does not navigate on open', () => {
-    const { getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    const { getByRole, getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    const dialog = getByRole('dialog', { name: '要離開嗎？' });
+    expect(dialog.getAttribute('aria-describedby')).toBe('exit-dialog-description');
     expect(getByTestId('exit-keep-seat')).toBeTruthy();
     expect(getByTestId('exit-leave-seat')).toBeTruthy();
     expect(getByTestId('exit-cancel')).toBeTruthy();
@@ -78,6 +80,13 @@ describe('ExitDialog (#420)', () => {
     expect(pushMock).not.toHaveBeenCalled();
     expect(leaveRoomMock).not.toHaveBeenCalled();
     expect(localStorage.getItem(CREDS_KEY)).not.toBeNull();
+  });
+
+  it('Escape requests dismissal through the native cancel event', () => {
+    const onClose = jest.fn();
+    const { getByRole } = render(<ExitDialog open onClose={onClose} matchID="room-1" />);
+    fireEvent(getByRole('dialog'), new Event('cancel', { cancelable: true }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('without saved credentials 離開座位 just returns to the lobby', async () => {

--- a/packages/webapp/src/components/board/ExitDialog.test.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import ExitDialog from './ExitDialog';
+
+const pushMock = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const leaveRoomMock = jest.fn();
+jest.mock('@/app/lobby/actions', () => ({
+  leaveRoom: (...args: unknown[]) => leaveRoomMock(...args),
+  getLobbyErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+const CREDS_KEY = 'open-star-ter-village.match-credentials.room-1';
+const seedCredentials = () => {
+  localStorage.setItem(
+    CREDS_KEY,
+    JSON.stringify({ matchID: 'room-1', playerID: '1', credential: 'secret', playerName: 'Bob' }),
+  );
+};
+
+describe('ExitDialog (#420)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    pushMock.mockReset();
+    leaveRoomMock.mockReset();
+  });
+
+  it('offers the three explicit choices and does not navigate on open', () => {
+    const { getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    expect(getByTestId('exit-keep-seat')).toBeTruthy();
+    expect(getByTestId('exit-leave-seat')).toBeTruthy();
+    expect(getByTestId('exit-cancel')).toBeTruthy();
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(leaveRoomMock).not.toHaveBeenCalled();
+  });
+
+  it('回大廳 navigates without releasing the seat or touching credentials', () => {
+    seedCredentials();
+    const { getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    fireEvent.click(getByTestId('exit-keep-seat'));
+    expect(pushMock).toHaveBeenCalledWith('/lobby');
+    expect(leaveRoomMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(CREDS_KEY)).not.toBeNull();
+  });
+
+  it('離開座位 releases the seat, clears credentials, then navigates', async () => {
+    seedCredentials();
+    leaveRoomMock.mockResolvedValue(undefined);
+    const { getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    fireEvent.click(getByTestId('exit-leave-seat'));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/lobby'));
+    expect(leaveRoomMock).toHaveBeenCalledWith('room-1', '1', 'secret');
+    expect(localStorage.getItem(CREDS_KEY)).toBeNull();
+  });
+
+  it('a failed leave keeps credentials, shows the error, and stays open', async () => {
+    seedCredentials();
+    leaveRoomMock.mockRejectedValue(new Error('boom'));
+    const { getByTestId, getByRole } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    fireEvent.click(getByTestId('exit-leave-seat'));
+    await waitFor(() => expect(getByRole('alert')).toBeTruthy());
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(CREDS_KEY)).not.toBeNull();
+  });
+
+  it('取消 closes without any side effect', () => {
+    seedCredentials();
+    const onClose = jest.fn();
+    const { getByTestId } = render(<ExitDialog open onClose={onClose} matchID="room-1" />);
+    fireEvent.click(getByTestId('exit-cancel'));
+    expect(onClose).toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(leaveRoomMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(CREDS_KEY)).not.toBeNull();
+  });
+
+  it('without saved credentials 離開座位 just returns to the lobby', async () => {
+    const { getByTestId } = render(<ExitDialog open onClose={jest.fn()} matchID="room-1" />);
+    fireEvent.click(getByTestId('exit-leave-seat'));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/lobby'));
+    expect(leaveRoomMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/src/components/board/ExitDialog.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
-import { StickerButton } from '@/components/design';
+import { Modal, StickerButton } from '@/components/design';
 import { getLobbyErrorMessage, leaveRoom } from '@/app/lobby/actions';
 import { clearCredentials, loadCredentials } from '@/lib/matchCredentials';
 
@@ -10,10 +9,7 @@ import { clearCredentials, loadCredentials } from '@/lib/matchCredentials';
  * 回大廳 keeps the seat + credentials so the lobby offers 回到桌子 (#421);
  * 離開座位 releases the seat via leaveMatch, which terminates the match for
  * everyone (remaining players see the terminated overlay); 取消 does nothing.
- *
- * Bespoke .modal overlay (no MUI): portaled to <body> to escape sticky-header
- * stacking contexts, with Escape/backdrop close, initial focus, a small Tab
- * cycle, and body scroll lock while open.
+ * Rendered in the shared bespoke Modal shell (no MUI).
  */
 export default function ExitDialog({
   open,
@@ -27,46 +23,7 @@ export default function ExitDialog({
   const router = useRouter();
   const [isLeaving, setIsLeaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const panelRef = React.useRef<HTMLDivElement>(null);
   const canClose = !isLeaving;
-
-  React.useEffect(() => {
-    if (!open) {
-      return;
-    }
-    panelRef.current?.focus();
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [open]);
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      if (canClose) {
-        onClose();
-      }
-      return;
-    }
-    if (event.key !== 'Tab') {
-      return;
-    }
-    // Keep Tab cycling inside the three buttons.
-    const focusables = panelRef.current?.querySelectorAll<HTMLElement>('button:not(:disabled)');
-    if (!focusables || focusables.length === 0) {
-      return;
-    }
-    const first = focusables[0];
-    const last = focusables[focusables.length - 1];
-    if (event.shiftKey && (document.activeElement === first || document.activeElement === panelRef.current)) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
 
   const handleLobbyKeepSeat = () => {
     router.push('/lobby');
@@ -91,71 +48,59 @@ export default function ExitDialog({
     }
   };
 
-  if (!open) {
-    return null;
-  }
-
-  return createPortal(
-    <div className="modal-backdrop" onClick={canClose ? onClose : undefined}>
-      <div
-        ref={panelRef}
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label="離開遊戲"
-        tabIndex={-1}
-        data-testid="exit-dialog"
-        style={{ width: 'min(420px, 100%)', fontFamily: 'var(--font-zh)', outline: 'none' }}
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
-          <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
-          <div>
-            <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
-            <div className="tag-en">Leave the game?</div>
-          </div>
-        </div>
-        <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
-          你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
-        </p>
-        {error && (
-          <p role="alert" style={{ fontSize: 12, fontWeight: 700, color: 'var(--orange-deep)', margin: '0 0 12px' }}>
-            ⚠ {error}
-          </p>
-        )}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          <StickerButton
-            variant="teal"
-            onClick={handleLobbyKeepSeat}
-            disabled={isLeaving}
-            style={{ width: '100%' }}
-            data-testid="exit-keep-seat"
-          >
-            回大廳（保留座位） <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Go to lobby</span>
-          </StickerButton>
-          <StickerButton
-            variant="ghost"
-            onClick={() => void handleLeaveSeat()}
-            disabled={isLeaving}
-            style={{ width: '100%', borderColor: 'var(--orange-deep)', color: 'var(--orange-deep)' }}
-            data-testid="exit-leave-seat"
-          >
-            {isLeaving ? '離開中…' : '離開座位（終止遊戲）'} <span className="tag-en">Leave seat</span>
-          </StickerButton>
-          <StickerButton
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            disabled={isLeaving}
-            style={{ width: '100%' }}
-            data-testid="exit-cancel"
-          >
-            取消 <span className="tag-en">Cancel</span>
-          </StickerButton>
+  return (
+    <Modal
+      open={open}
+      onClose={canClose ? onClose : undefined}
+      ariaLabel="離開遊戲"
+      width="min(420px, 100%)"
+      dataTestid="exit-dialog"
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+        <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
+        <div>
+          <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
+          <div className="tag-en">Leave the game?</div>
         </div>
       </div>
-    </div>,
-    document.body,
+      <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
+        你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
+      </p>
+      {error && (
+        <p role="alert" style={{ fontSize: 12, fontWeight: 700, color: 'var(--orange-deep)', margin: '0 0 12px' }}>
+          ⚠ {error}
+        </p>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <StickerButton
+          variant="teal"
+          onClick={handleLobbyKeepSeat}
+          disabled={isLeaving}
+          style={{ width: '100%' }}
+          data-testid="exit-keep-seat"
+        >
+          回大廳（保留座位） <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Go to lobby</span>
+        </StickerButton>
+        <StickerButton
+          variant="ghost"
+          onClick={() => void handleLeaveSeat()}
+          disabled={isLeaving}
+          style={{ width: '100%', borderColor: 'var(--orange-deep)', color: 'var(--orange-deep)' }}
+          data-testid="exit-leave-seat"
+        >
+          {isLeaving ? '離開中…' : '離開座位（終止遊戲）'} <span className="tag-en">Leave seat</span>
+        </StickerButton>
+        <StickerButton
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          disabled={isLeaving}
+          style={{ width: '100%' }}
+          data-testid="exit-cancel"
+        >
+          取消 <span className="tag-en">Cancel</span>
+        </StickerButton>
+      </div>
+    </Modal>
   );
 }

--- a/packages/webapp/src/components/board/ExitDialog.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.tsx
@@ -52,18 +52,24 @@ export default function ExitDialog({
     <Modal
       open={open}
       onClose={canClose ? onClose : undefined}
-      ariaLabel="離開遊戲"
+      ariaLabelledBy="exit-dialog-title"
+      ariaDescribedBy="exit-dialog-description"
       width="min(420px, 100%)"
       dataTestid="exit-dialog"
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
         <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
         <div>
-          <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
+          <strong id="exit-dialog-title" style={{ fontSize: 16, color: 'var(--ink)' }}>
+            要離開嗎？
+          </strong>
           <div className="tag-en">Leave the game?</div>
         </div>
       </div>
-      <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
+      <p
+        id="exit-dialog-description"
+        style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}
+      >
         你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
       </p>
       {error && (

--- a/packages/webapp/src/components/board/ExitDialog.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
-import { Dialog, DialogContent } from '@mui/material';
 import { StickerButton } from '@/components/design';
 import { getLobbyErrorMessage, leaveRoom } from '@/app/lobby/actions';
 import { clearCredentials, loadCredentials } from '@/lib/matchCredentials';
@@ -10,6 +10,10 @@ import { clearCredentials, loadCredentials } from '@/lib/matchCredentials';
  * 回大廳 keeps the seat + credentials so the lobby offers 回到桌子 (#421);
  * 離開座位 releases the seat via leaveMatch, which terminates the match for
  * everyone (remaining players see the terminated overlay); 取消 does nothing.
+ *
+ * Bespoke .modal overlay (no MUI): portaled to <body> to escape sticky-header
+ * stacking contexts, with Escape/backdrop close, initial focus, a small Tab
+ * cycle, and body scroll lock while open.
  */
 export default function ExitDialog({
   open,
@@ -23,6 +27,46 @@ export default function ExitDialog({
   const router = useRouter();
   const [isLeaving, setIsLeaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const canClose = !isLeaving;
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    panelRef.current?.focus();
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      if (canClose) {
+        onClose();
+      }
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    // Keep Tab cycling inside the three buttons.
+    const focusables = panelRef.current?.querySelectorAll<HTMLElement>('button:not(:disabled)');
+    if (!focusables || focusables.length === 0) {
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && (document.activeElement === first || document.activeElement === panelRef.current)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const handleLobbyKeepSeat = () => {
     router.push('/lobby');
@@ -47,57 +91,71 @@ export default function ExitDialog({
     }
   };
 
-  return (
-    <Dialog open={open} onClose={isLeaving ? undefined : onClose} maxWidth="xs" fullWidth aria-label="離開遊戲">
-      <DialogContent sx={{ p: 0 }}>
-        <div data-testid="exit-dialog" style={{ padding: 22, background: 'var(--paper)', fontFamily: 'var(--font-zh)' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
-            <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
-            <div>
-              <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
-              <div className="tag-en">Leave the game?</div>
-            </div>
-          </div>
-          <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
-            你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
-          </p>
-          {error && (
-            <p role="alert" style={{ fontSize: 12, fontWeight: 700, color: 'var(--orange-deep)', margin: '0 0 12px' }}>
-              ⚠ {error}
-            </p>
-          )}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            <StickerButton
-              variant="teal"
-              onClick={handleLobbyKeepSeat}
-              disabled={isLeaving}
-              style={{ width: '100%' }}
-              data-testid="exit-keep-seat"
-            >
-              回大廳（保留座位） <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Go to lobby</span>
-            </StickerButton>
-            <StickerButton
-              variant="ghost"
-              onClick={() => void handleLeaveSeat()}
-              disabled={isLeaving}
-              style={{ width: '100%', borderColor: 'var(--orange-deep)', color: 'var(--orange-deep)' }}
-              data-testid="exit-leave-seat"
-            >
-              {isLeaving ? '離開中…' : '離開座位（終止遊戲）'} <span className="tag-en">Leave seat</span>
-            </StickerButton>
-            <StickerButton
-              variant="ghost"
-              size="sm"
-              onClick={onClose}
-              disabled={isLeaving}
-              style={{ width: '100%' }}
-              data-testid="exit-cancel"
-            >
-              取消 <span className="tag-en">Cancel</span>
-            </StickerButton>
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="modal-backdrop" onClick={canClose ? onClose : undefined}>
+      <div
+        ref={panelRef}
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="離開遊戲"
+        tabIndex={-1}
+        data-testid="exit-dialog"
+        style={{ width: 'min(420px, 100%)', fontFamily: 'var(--font-zh)', outline: 'none' }}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+          <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
+          <div>
+            <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
+            <div className="tag-en">Leave the game?</div>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+        <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
+          你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
+        </p>
+        {error && (
+          <p role="alert" style={{ fontSize: 12, fontWeight: 700, color: 'var(--orange-deep)', margin: '0 0 12px' }}>
+            ⚠ {error}
+          </p>
+        )}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <StickerButton
+            variant="teal"
+            onClick={handleLobbyKeepSeat}
+            disabled={isLeaving}
+            style={{ width: '100%' }}
+            data-testid="exit-keep-seat"
+          >
+            回大廳（保留座位） <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Go to lobby</span>
+          </StickerButton>
+          <StickerButton
+            variant="ghost"
+            onClick={() => void handleLeaveSeat()}
+            disabled={isLeaving}
+            style={{ width: '100%', borderColor: 'var(--orange-deep)', color: 'var(--orange-deep)' }}
+            data-testid="exit-leave-seat"
+          >
+            {isLeaving ? '離開中…' : '離開座位（終止遊戲）'} <span className="tag-en">Leave seat</span>
+          </StickerButton>
+          <StickerButton
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            disabled={isLeaving}
+            style={{ width: '100%' }}
+            data-testid="exit-cancel"
+          >
+            取消 <span className="tag-en">Cancel</span>
+          </StickerButton>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/webapp/src/components/board/ExitDialog.tsx
+++ b/packages/webapp/src/components/board/ExitDialog.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Dialog, DialogContent } from '@mui/material';
+import { StickerButton } from '@/components/design';
+import { getLobbyErrorMessage, leaveRoom } from '@/app/lobby/actions';
+import { clearCredentials, loadCredentials } from '@/lib/matchCredentials';
+
+/**
+ * Leave confirmation (#420, design: GpExitDialog). Three explicit choices:
+ * 回大廳 keeps the seat + credentials so the lobby offers 回到桌子 (#421);
+ * 離開座位 releases the seat via leaveMatch, which terminates the match for
+ * everyone (remaining players see the terminated overlay); 取消 does nothing.
+ */
+export default function ExitDialog({
+  open,
+  onClose,
+  matchID,
+}: {
+  open: boolean;
+  onClose: () => void;
+  matchID: string;
+}) {
+  const router = useRouter();
+  const [isLeaving, setIsLeaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleLobbyKeepSeat = () => {
+    router.push('/lobby');
+  };
+
+  const handleLeaveSeat = async () => {
+    const credentials = loadCredentials(matchID);
+    if (!credentials) {
+      // Nothing to release (observer or local play) — just go back.
+      router.push('/lobby');
+      return;
+    }
+    setIsLeaving(true);
+    setError(null);
+    try {
+      await leaveRoom(matchID, credentials.playerID, credentials.credential);
+      clearCredentials(matchID);
+      router.push('/lobby');
+    } catch (leaveError) {
+      setError(getLobbyErrorMessage(leaveError, '無法離開座位，請稍後再試。 · Unable to leave the seat.'));
+      setIsLeaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={isLeaving ? undefined : onClose} maxWidth="xs" fullWidth aria-label="離開遊戲">
+      <DialogContent sx={{ p: 0 }}>
+        <div data-testid="exit-dialog" style={{ padding: 22, background: 'var(--paper)', fontFamily: 'var(--font-zh)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+            <span aria-hidden style={{ fontSize: 22 }}>🚪</span>
+            <div>
+              <strong style={{ fontSize: 16, color: 'var(--ink)' }}>要離開嗎？</strong>
+              <div className="tag-en">Leave the game?</div>
+            </div>
+          </div>
+          <p style={{ fontSize: 13, color: 'var(--ink-soft)', lineHeight: 1.5, margin: '6px 0 16px' }}>
+            你可以回到大廳並保留座位，隨時回來繼續；或直接離席（這局遊戲會終止）。
+          </p>
+          {error && (
+            <p role="alert" style={{ fontSize: 12, fontWeight: 700, color: 'var(--orange-deep)', margin: '0 0 12px' }}>
+              ⚠ {error}
+            </p>
+          )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <StickerButton
+              variant="teal"
+              onClick={handleLobbyKeepSeat}
+              disabled={isLeaving}
+              style={{ width: '100%' }}
+              data-testid="exit-keep-seat"
+            >
+              回大廳（保留座位） <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Go to lobby</span>
+            </StickerButton>
+            <StickerButton
+              variant="ghost"
+              onClick={() => void handleLeaveSeat()}
+              disabled={isLeaving}
+              style={{ width: '100%', borderColor: 'var(--orange-deep)', color: 'var(--orange-deep)' }}
+              data-testid="exit-leave-seat"
+            >
+              {isLeaving ? '離開中…' : '離開座位（終止遊戲）'} <span className="tag-en">Leave seat</span>
+            </StickerButton>
+            <StickerButton
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              disabled={isLeaving}
+              style={{ width: '100%' }}
+              data-testid="exit-cancel"
+            >
+              取消 <span className="tag-en">Cancel</span>
+            </StickerButton>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -1,13 +1,16 @@
-import Link from 'next/link';
+import React from 'react';
 import { PlayerID } from 'boardgame.io';
 import { AppHeader, PLAYER_COLORS } from '@/components/design';
 import { GameContext } from '@/components/GameContextHelpers';
 import { PlayersSelector } from '@/game/store/slice/players';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from '@/components/playerNameMap';
+import ExitDialog from './ExitDialog';
 
 /** Sticky table header: shared app shell + per-player status chips (design: GameHeader).
- *  `compact` (mobile): chips scroll horizontally instead of wrapping. */
+ *  `compact` (mobile): only the seated player's chip + a ⋯ menu holding the
+ *  secondary actions; desktop shows every chip and a Leave button. Leaving
+ *  always goes through the explicit exit-choice dialog (#420). */
 export default function GameHeader({
   gameContext,
   compact = false,
@@ -15,7 +18,21 @@ export default function GameHeader({
   gameContext: GameContext;
   compact?: boolean;
 }) {
-  const { G, ctx, playerID, matchData } = gameContext;
+  const { G, ctx, playerID, matchData, matchID } = gameContext;
+  const [exitOpen, setExitOpen] = React.useState(false);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  // Mobile shows only your own chip; observers keep the full row.
+  const chipIDs =
+    compact && playerID !== null && G.players[playerID]
+      ? [playerID]
+      : Object.keys(G.players);
+
+  const openExit = () => {
+    setMenuOpen(false);
+    setExitOpen(true);
+  };
+
   return (
     <AppHeader
       sticky
@@ -31,11 +48,12 @@ export default function GameHeader({
               overflowX: compact ? 'auto' : 'visible',
               minWidth: 0,
               flex: compact ? 1 : undefined,
+              justifyContent: compact ? 'flex-end' : undefined,
               // Headroom for the TURN badge that overflows the active chip.
               paddingTop: 8,
             }}
           >
-            {Object.keys(G.players).map((id) => (
+            {chipIDs.map((id) => (
               <PlayerHeaderChip
                 key={id}
                 id={id}
@@ -48,9 +66,65 @@ export default function GameHeader({
               />
             ))}
           </div>
-          <Link href="/lobby" className="btn-sticker sm ghost" style={{ flexShrink: 0 }}>
-            離開 {!compact && <span className="tag-en">Leave</span>}
-          </Link>
+          {compact ? (
+            <div style={{ position: 'relative', flexShrink: 0 }}>
+              <button
+                type="button"
+                className="icon-btn"
+                aria-label="選單 · Menu"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                data-testid="header-menu"
+                onClick={() => setMenuOpen((open) => !open)}
+              >
+                ⋯
+              </button>
+              {menuOpen && (
+                <>
+                  <div
+                    aria-hidden
+                    onClick={() => setMenuOpen(false)}
+                    style={{ position: 'fixed', inset: 0, zIndex: 40 }}
+                  />
+                  <div
+                    role="menu"
+                    style={{
+                      position: 'absolute',
+                      right: 0,
+                      top: 'calc(100% + 6px)',
+                      zIndex: 41,
+                      background: 'white',
+                      border: '2px solid var(--ink)',
+                      borderRadius: 14,
+                      boxShadow: 'var(--shadow-sticker)',
+                      padding: 6,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 2,
+                      minWidth: 190,
+                    }}
+                  >
+                    <button type="button" role="menuitem" className="menu-item" data-testid="menu-leave" onClick={openExit}>
+                      🚪 離開遊戲 <span className="tag-en">Leave</span>
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="btn-sticker sm ghost"
+              style={{ flexShrink: 0 }}
+              data-testid="header-leave"
+              onClick={openExit}
+            >
+              離開 <span className="tag-en">Leave</span>
+            </button>
+          )}
+          {/* Mounted lazily: ExitDialog uses the app router, which only exists
+              once the user can actually open it. */}
+          {exitOpen && <ExitDialog open onClose={() => setExitOpen(false)} matchID={matchID} />}
         </>
       }
     />

--- a/packages/webapp/src/components/design/Modal.tsx
+++ b/packages/webapp/src/components/design/Modal.tsx
@@ -11,6 +11,8 @@ export default function Modal({
   open,
   onClose,
   ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
   role,
   width = 'min(560px, 100%)',
   dataTestid,
@@ -19,7 +21,9 @@ export default function Modal({
   open: boolean;
   /** Omit to make the modal non-dismissible (no Escape/backdrop close). */
   onClose?: () => void;
-  ariaLabel: string;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
   /** Defaults to the dialog element's implicit role. */
   role?: 'alertdialog';
   width?: string;
@@ -27,12 +31,6 @@ export default function Modal({
   children: React.ReactNode;
 }) {
   const dialogRef = React.useRef<HTMLDialogElement>(null);
-  // Latest onClose without re-running the open effect (React 18 does not
-  // delegate the dialog element's cancel event, so it is bound manually).
-  const onCloseRef = React.useRef(onClose);
-  React.useEffect(() => {
-    onCloseRef.current = onClose;
-  });
 
   React.useEffect(() => {
     const dialog = dialogRef.current;
@@ -49,14 +47,8 @@ export default function Modal({
     // event: close() is queued as a task, so under StrictMode's
     // mount→cleanup→remount the cleanup's close() would deliver a stray close
     // to the remounted dialog and tear it right back down.
-    const handleCancel = (event: Event) => {
-      event.preventDefault();
-      onCloseRef.current?.();
-    };
-    dialog.addEventListener('cancel', handleCancel);
     dialog.showModal();
     return () => {
-      dialog.removeEventListener('cancel', handleCancel);
       dialog.close();
       if (invoker && document.contains(invoker)) {
         invoker.focus();
@@ -73,9 +65,15 @@ export default function Modal({
       ref={dialogRef}
       className="modal"
       aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
       role={role}
       data-testid={dataTestid}
       style={{ width, fontFamily: 'var(--font-zh)' }}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose?.();
+      }}
       onClick={(event) => {
         // ::backdrop clicks target the dialog element itself; a click inside
         // the panel's bounding box (e.g. its padding) must not dismiss.

--- a/packages/webapp/src/components/design/Modal.tsx
+++ b/packages/webapp/src/components/design/Modal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Bespoke sticker modal (prototype .modal / .modal-backdrop) — the no-MUI
+ * dialog shell. Portaled to <body> to escape sticky-header stacking
+ * contexts, with Escape/backdrop close (when onClose is provided), initial
+ * focus, a small Tab cycle, and body scroll lock while open.
+ */
+export default function Modal({
+  open,
+  onClose,
+  ariaLabel,
+  width = 'min(560px, 100%)',
+  dataTestid,
+  children,
+}: {
+  open: boolean;
+  /** Omit to make the modal non-dismissible (no Escape/backdrop close). */
+  onClose?: () => void;
+  ariaLabel: string;
+  width?: string;
+  dataTestid?: string;
+  children: React.ReactNode;
+}) {
+  const panelRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    panelRef.current?.focus();
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      onClose?.();
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    // Keep Tab cycling inside the panel.
+    const focusables = panelRef.current?.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    if (!focusables || focusables.length === 0) {
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && (document.activeElement === first || document.activeElement === panelRef.current)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        ref={panelRef}
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        tabIndex={-1}
+        data-testid={dataTestid}
+        style={{ width, fontFamily: 'var(--font-zh)', outline: 'none' }}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/webapp/src/components/design/Modal.tsx
+++ b/packages/webapp/src/components/design/Modal.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { createPortal } from 'react-dom';
 
 /**
- * Bespoke sticker modal (prototype .modal / .modal-backdrop) — the no-MUI
- * dialog shell. Portaled to <body> to escape sticky-header stacking
- * contexts, with Escape/backdrop close (when onClose is provided), initial
- * focus, a small Tab cycle, and body scroll lock while open.
+ * Bespoke sticker modal (prototype .modal) — the no-MUI dialog shell, built
+ * on the native <dialog> element. showModal() supplies top-layer rendering,
+ * an inert background (a real focus trap), Escape via the cancel event, and
+ * focus restoration to the invoking element on close. Backdrop clicks close
+ * it when onClose is provided; body scroll locks via CSS while open.
  */
 export default function Modal({
   open,
   onClose,
   ariaLabel,
+  role,
   width = 'min(560px, 100%)',
   dataTestid,
   children,
@@ -19,71 +20,81 @@ export default function Modal({
   /** Omit to make the modal non-dismissible (no Escape/backdrop close). */
   onClose?: () => void;
   ariaLabel: string;
+  /** Defaults to the dialog element's implicit role. */
+  role?: 'alertdialog';
   width?: string;
   dataTestid?: string;
   children: React.ReactNode;
 }) {
-  const panelRef = React.useRef<HTMLDivElement>(null);
+  const dialogRef = React.useRef<HTMLDialogElement>(null);
+  // Latest onClose without re-running the open effect (React 18 does not
+  // delegate the dialog element's cancel event, so it is bound manually).
+  const onCloseRef = React.useRef(onClose);
+  React.useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   React.useEffect(() => {
-    if (!open) {
+    const dialog = dialogRef.current;
+    if (!open || !dialog) {
       return;
     }
-    panelRef.current?.focus();
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    // Restore focus to the invoking control on close. Explicit rather than
+    // relying on <dialog>'s native restoration, which StrictMode's
+    // mount→cleanup→remount disturbs (the cleanup close() re-homes focus
+    // before the remount records its invoker).
+    const invoker = document.activeElement as HTMLElement | null;
+    // Escape fires `cancel`; always preventDefault and let React drive the
+    // unmount (which calls close()). Dismissal is never wired to the `close`
+    // event: close() is queued as a task, so under StrictMode's
+    // mount→cleanup→remount the cleanup's close() would deliver a stray close
+    // to the remounted dialog and tear it right back down.
+    const handleCancel = (event: Event) => {
+      event.preventDefault();
+      onCloseRef.current?.();
+    };
+    dialog.addEventListener('cancel', handleCancel);
+    dialog.showModal();
     return () => {
-      document.body.style.overflow = previousOverflow;
+      dialog.removeEventListener('cancel', handleCancel);
+      dialog.close();
+      if (invoker && document.contains(invoker)) {
+        invoker.focus();
+      }
     };
   }, [open]);
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      onClose?.();
-      return;
-    }
-    if (event.key !== 'Tab') {
-      return;
-    }
-    // Keep Tab cycling inside the panel.
-    const focusables = panelRef.current?.querySelectorAll<HTMLElement>(
-      'button:not(:disabled), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-    );
-    if (!focusables || focusables.length === 0) {
-      return;
-    }
-    const first = focusables[0];
-    const last = focusables[focusables.length - 1];
-    if (event.shiftKey && (document.activeElement === first || document.activeElement === panelRef.current)) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
 
   if (!open) {
     return null;
   }
 
-  return createPortal(
-    <div className="modal-backdrop" onClick={onClose}>
-      <div
-        ref={panelRef}
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label={ariaLabel}
-        tabIndex={-1}
-        data-testid={dataTestid}
-        style={{ width, fontFamily: 'var(--font-zh)', outline: 'none' }}
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        {children}
-      </div>
-    </div>,
-    document.body,
+  return (
+    <dialog
+      ref={dialogRef}
+      className="modal"
+      aria-label={ariaLabel}
+      role={role}
+      data-testid={dataTestid}
+      style={{ width, fontFamily: 'var(--font-zh)' }}
+      onClick={(event) => {
+        // ::backdrop clicks target the dialog element itself; a click inside
+        // the panel's bounding box (e.g. its padding) must not dismiss.
+        const dialog = dialogRef.current;
+        if (!onClose || !dialog || event.target !== dialog) {
+          return;
+        }
+        const rect = dialog.getBoundingClientRect();
+        const inPanel =
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom;
+        if (!inPanel) {
+          onClose();
+        }
+      }}
+    >
+      {children}
+    </dialog>
   );
 }

--- a/packages/webapp/src/components/design/index.ts
+++ b/packages/webapp/src/components/design/index.ts
@@ -1,6 +1,7 @@
 export { default as AppHeader } from './AppHeader';
 export { default as Logo } from './Logo';
 export { default as StickerButton } from './StickerButton';
+export { default as Modal } from './Modal';
 export { default as PaperCard } from './PaperCard';
 export { default as CharacterAvatar } from './CharacterAvatar';
 export {

--- a/packages/webapp/src/components/lobby/MatchRow.test.tsx
+++ b/packages/webapp/src/components/lobby/MatchRow.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import MatchRow, { getMatchRowAction } from './MatchRow';
+import type { LobbyStatus, VisibleMatch } from '@/app/lobby/actions';
+
+const match = { matchID: 'room-1', createdAt: 1700000000000, updatedAt: 1700000000000 } as VisibleMatch['match'];
+
+const renderRow = (status: LobbyStatus, hasSeat: boolean) => {
+  const onJoin = jest.fn();
+  const onReturn = jest.fn();
+  const onSpectate = jest.fn();
+  const utils = render(
+    <MatchRow
+      match={match}
+      seatsFilled={3}
+      totalSeats={3}
+      status={status}
+      hasSeat={hasSeat}
+      joining={false}
+      busy={false}
+      onJoin={onJoin}
+      onReturn={onReturn}
+      onSpectate={onSpectate}
+    />,
+  );
+  return { ...utils, onJoin, onReturn, onSpectate };
+};
+
+describe('getMatchRowAction (#421)', () => {
+  it.each([
+    ['In Progress', true, 'return'],
+    ['Waiting', true, 'return'],
+    ['Full', true, 'return'],
+    ['In Progress', false, 'spectate'],
+    ['Waiting', false, 'join'],
+    ['Full', false, 'join'],
+  ] as const)('%s + hasSeat=%s → %s', (status, hasSeat, expected) => {
+    expect(getMatchRowAction(status, hasSeat)).toBe(expected);
+  });
+});
+
+describe('MatchRow actions', () => {
+  it('回到桌子 for the room this browser holds a seat in', () => {
+    const { getByTestId, queryByTestId, onReturn } = renderRow('In Progress', true);
+    fireEvent.click(getByTestId('match-return'));
+    expect(onReturn).toHaveBeenCalled();
+    expect(queryByTestId('match-join')).toBeNull();
+    expect(queryByTestId('match-spectate')).toBeNull();
+  });
+
+  it('觀戰 for other in-progress rooms', () => {
+    const { getByTestId, queryByTestId, onSpectate } = renderRow('In Progress', false);
+    fireEvent.click(getByTestId('match-spectate'));
+    expect(onSpectate).toHaveBeenCalled();
+    expect(queryByTestId('match-return')).toBeNull();
+  });
+
+  it('加入 stays for waiting rooms and is disabled for full ones', () => {
+    const waiting = renderRow('Waiting', false);
+    fireEvent.click(waiting.getByTestId('match-join'));
+    expect(waiting.onJoin).toHaveBeenCalled();
+    waiting.unmount();
+
+    const full = renderRow('Full', false);
+    expect((full.getByTestId('match-join') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/webapp/src/components/lobby/MatchRow.test.tsx
+++ b/packages/webapp/src/components/lobby/MatchRow.test.tsx
@@ -10,8 +10,7 @@ const match = { matchID: 'room-1', createdAt: 1700000000000, updatedAt: 17000000
 
 const renderRow = (status: LobbyStatus, hasSeat: boolean) => {
   const onJoin = jest.fn();
-  const onReturn = jest.fn();
-  const onSpectate = jest.fn();
+  const onOpen = jest.fn();
   const utils = render(
     <MatchRow
       match={match}
@@ -22,11 +21,10 @@ const renderRow = (status: LobbyStatus, hasSeat: boolean) => {
       joining={false}
       busy={false}
       onJoin={onJoin}
-      onReturn={onReturn}
-      onSpectate={onSpectate}
+      onOpen={onOpen}
     />,
   );
-  return { ...utils, onJoin, onReturn, onSpectate };
+  return { ...utils, onJoin, onOpen };
 };
 
 describe('getMatchRowAction (#421)', () => {
@@ -44,17 +42,17 @@ describe('getMatchRowAction (#421)', () => {
 
 describe('MatchRow actions', () => {
   it('回到桌子 for the room this browser holds a seat in', () => {
-    const { getByTestId, queryByTestId, onReturn } = renderRow('In Progress', true);
+    const { getByTestId, queryByTestId, onOpen } = renderRow('In Progress', true);
     fireEvent.click(getByTestId('match-return'));
-    expect(onReturn).toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalled();
     expect(queryByTestId('match-join')).toBeNull();
     expect(queryByTestId('match-spectate')).toBeNull();
   });
 
   it('觀戰 for other in-progress rooms', () => {
-    const { getByTestId, queryByTestId, onSpectate } = renderRow('In Progress', false);
+    const { getByTestId, queryByTestId, onOpen } = renderRow('In Progress', false);
     fireEvent.click(getByTestId('match-spectate'));
-    expect(onSpectate).toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalled();
     expect(queryByTestId('match-return')).toBeNull();
   });
 

--- a/packages/webapp/src/components/lobby/MatchRow.tsx
+++ b/packages/webapp/src/components/lobby/MatchRow.tsx
@@ -1,0 +1,131 @@
+import { StickerButton } from '@/components/design';
+import type { LobbyStatus, VisibleMatch } from '@/app/lobby/actions';
+
+export type MatchRowAction = 'return' | 'spectate' | 'join';
+
+/**
+ * Which primary action a lobby room offers this user (#421):
+ * - a saved seat in the room → 回到桌子 (resume with existing credentials)
+ * - another in-progress room → 觀戰 (read-only observer)
+ * - otherwise → 加入 (normal join; disabled unless the room is Waiting)
+ */
+export function getMatchRowAction(status: LobbyStatus, hasSeat: boolean): MatchRowAction {
+  if (hasSeat) return 'return';
+  if (status === 'In Progress') return 'spectate';
+  return 'join';
+}
+
+export default function MatchRow({
+  match,
+  seatsFilled,
+  totalSeats,
+  status,
+  hasSeat,
+  joining,
+  busy,
+  onJoin,
+  onReturn,
+  onSpectate,
+}: {
+  match: VisibleMatch['match'];
+  seatsFilled: number;
+  totalSeats: number;
+  status: LobbyStatus;
+  /** This browser holds saved credentials for a seat in the room. */
+  hasSeat: boolean;
+  joining: boolean;
+  /** A join/create is in flight somewhere in the lobby. */
+  busy: boolean;
+  onJoin: () => void;
+  onReturn: () => void;
+  onSpectate: () => void;
+}) {
+  const action = getMatchRowAction(status, hasSeat);
+  return (
+    <div
+      data-testid={`match-row-${match.matchID}`}
+      data-action={action}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '10px 14px',
+        background: 'white',
+        border: '1.5px solid var(--ink)',
+        borderRadius: 12,
+        boxShadow: '0 2px 0 var(--ink)',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            fontWeight: 700,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {match.matchID}
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--ink-mute)', marginTop: 2 }}>
+          {formatDate(match.createdAt)} · {status}
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+        {Array.from({ length: totalSeats }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 999,
+              background: i < seatsFilled ? 'var(--orange)' : 'white',
+              border: '1.5px solid var(--ink)',
+            }}
+          />
+        ))}
+        <span
+          style={{
+            marginLeft: 4,
+            fontSize: 11,
+            fontWeight: 700,
+            color: 'var(--ink-soft)',
+            fontFamily: 'var(--font-en)',
+          }}
+        >
+          {seatsFilled}/{totalSeats}
+        </span>
+      </div>
+      {action === 'return' && (
+        <StickerButton size="sm" onClick={onReturn} disabled={busy} data-testid="match-return">
+          回到桌子 · Return
+        </StickerButton>
+      )}
+      {action === 'spectate' && (
+        <StickerButton variant="ghost" size="sm" onClick={onSpectate} disabled={busy} data-testid="match-spectate">
+          觀戰 · Spectate
+        </StickerButton>
+      )}
+      {action === 'join' && (
+        <StickerButton
+          variant="teal"
+          size="sm"
+          onClick={onJoin}
+          disabled={status !== 'Waiting' || busy}
+          data-testid="match-join"
+        >
+          {joining ? '加入中… · Joining' : '加入 · Join'}
+        </StickerButton>
+      )}
+    </div>
+  );
+}
+
+function formatDate(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(timestamp);
+}

--- a/packages/webapp/src/components/lobby/MatchRow.tsx
+++ b/packages/webapp/src/components/lobby/MatchRow.tsx
@@ -24,8 +24,7 @@ export default function MatchRow({
   joining,
   busy,
   onJoin,
-  onReturn,
-  onSpectate,
+  onOpen,
 }: {
   match: VisibleMatch['match'];
   seatsFilled: number;
@@ -37,8 +36,8 @@ export default function MatchRow({
   /** A join/create is in flight somewhere in the lobby. */
   busy: boolean;
   onJoin: () => void;
-  onReturn: () => void;
-  onSpectate: () => void;
+  /** Open the room page — resumes your seat or spectates, decided there. */
+  onOpen: () => void;
 }) {
   const action = getMatchRowAction(status, hasSeat);
   return (
@@ -99,12 +98,12 @@ export default function MatchRow({
         </span>
       </div>
       {action === 'return' && (
-        <StickerButton size="sm" onClick={onReturn} disabled={busy} data-testid="match-return">
+        <StickerButton size="sm" onClick={onOpen} disabled={busy} data-testid="match-return">
           回到桌子 · Return
         </StickerButton>
       )}
       {action === 'spectate' && (
-        <StickerButton variant="ghost" size="sm" onClick={onSpectate} disabled={busy} data-testid="match-spectate">
+        <StickerButton variant="ghost" size="sm" onClick={onOpen} disabled={busy} data-testid="match-spectate">
           觀戰 · Spectate
         </StickerButton>
       )}


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Fixes #420 and #421: leaving a game now goes through an explicit three-choice dialog (回大廳保留座位 / 離開座位終止遊戲 / 取消) instead of a bare link, and the lobby recognizes each room's relationship to the player — 回到桌子 for your own in-progress table (credential-based, never name matching), 觀戰 for other running games, 加入 for waiting rooms. Releasing a seat mid-game terminates the match for the whole table.

## Changes

- **ExitDialog** (`board/ExitDialog.tsx`, design GpExitDialog): 回大廳 navigates keeping seat + credentials; 離開座位 calls `leaveMatch`, clears credentials, then navigates (error keeps state and shows a bilingual alert); 取消/Escape/backdrop close safely. Opened lazily from GameHeader — no navigation before an explicit choice.
- **Modal** (`design/Modal.tsx`, no MUI per maintainer direction): shared dialog shell on the native `<dialog>` element via `showModal()` — top-layer rendering, inert-background focus trap, Escape through the `cancel` event, and explicit focus restoration to the invoking control on close. Used by ExitDialog, the terminated-match overlay, and **GameOverDialog** — no MUI dialog and no `.Mui*` CSS remain in the app.
- **GameHeader**: desktop Leave button opens the dialog; compact mobile header now shows only the seated player's chip plus a ⋯ menu (`aria-haspopup`, 44px targets) holding 離開遊戲 — hints and bug-report items join it in the next PRs.
- **Terminated match**: a mixed named/unnamed seat list in a running multiplayer match (someone released their seat) shows a non-dismissible 有玩家離席，遊戲已終止 overlay (rendered through the shared non-dismissible Modal, so the background is genuinely inert) with 回大廳; dev-harness matches (all seats unnamed) are unaffected. Combined with the #424 lobby filter, the abandoned room is hidden from the lobby.
- **Lobby MatchRow** (extracted to `components/lobby/MatchRow.tsx` with pure `getMatchRowAction`): 回到桌子 (saved credentials exist; routes without re-join — the room page still validates them against the server and demotes to observer when stale) / 觀戰 (other In Progress rooms → existing observer mode) / 加入 (Waiting; disabled for Full). 回到桌子 and 觀戰 share one `onOpen` callback (both just route to the room).
- **globals.css**: `.icon-btn` and `.menu-item` utilities (prototype parity, 44px touch minimum), plus the `.modal` sticker panel + `::backdrop` styling for the native `<dialog>` shell (2px ink border, 22px corner, sticker shadow, warm backdrop; `margin:auto` restores centering the global reset strips). No `.Mui*` CSS remains. The speculative `.icon-btn[data-on]` rule (no consumer in this PR) moved to #426 with its hints-toggle producer.

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:** <!-- Required when "Evidence not applicable" is selected. -->

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Leave opens the three-choice dialog; no navigation before a choice | Live 3-player match, Alice taps 離開 | ![exit dialog](https://raw.githubusercontent.com/ocftw/open-star-ter-village/4c132559976fb797920457914b9773cdd2ab663d/evidence/1-exit-dialog.png) |
| 回大廳 keeps the seat; the lobby then offers 回到桌子 and resuming restores the same seat (not observer) | Alice keeps seat → lobby row → 回到桌子 → board without observer banner | ![return](https://raw.githubusercontent.com/ocftw/open-star-ter-village/4c132559976fb797920457914b9773cdd2ab663d/evidence/2-lobby-return-to-table.png) |
| Other running games offer 觀戰 which lands in read-only observer mode | Fresh browser context on the same room | ![spectate](https://raw.githubusercontent.com/ocftw/open-star-ter-village/4c132559976fb797920457914b9773cdd2ab663d/evidence/3-lobby-spectate.png) |
| 離開座位 terminates the match: remaining players get a blocking notice and the room leaves the lobby | Bob releases his seat; Alice's board; Bob's refreshed lobby | ![terminated](https://raw.githubusercontent.com/ocftw/open-star-ter-village/4c132559976fb797920457914b9773cdd2ab663d/evidence/4-terminated-overlay.png) |
| Compact mobile header uses a ⋯ menu with the leave entry | Dev harness at 390×780 | ![mobile menu](https://raw.githubusercontent.com/ocftw/open-star-ter-village/4c132559976fb797920457914b9773cdd2ab663d/evidence/5-mobile-menu.png) |
| Dialog semantics (keep-seat leaves credentials, leave-seat clears them, cancel is side-effect free, failure keeps state) | `ExitDialog.test.tsx` — 6 component tests; `MatchRow.test.tsx` — action matrix (9 tests) | Jest 139/139 pass at 0e82a9d3 |
| End-to-end flows | `multiplayer.spec.ts` +3 scenarios (spectate row, keep-seat→return, leave-seat→terminate); `mobile.spec.ts` +1 (⋯ menu) | Playwright 30/30 pass at 0e82a9d3 (multiplayer+mobile 20, game-flow 10) |
| GameOverDialog behaves unchanged on the shared bespoke Modal shell | The five existing result-dialog component tests (ties/ranking, credential-gated rematch, playAgain flow, failure, close) run against the migrated shell | [`GameOverDialog.test.tsx`](https://github.com/ocftw/open-star-ter-village/blob/0e82a9d359ef3cb83c73b206ff8d0c07218d0395/packages/webapp/src/components/GameOverDialog.test.tsx) |

Local gate at 0e82a9d3: `next lint` clean, `tsc --noEmit` clean for app and server configs, `jest --runInBand` 139/139, Playwright 30/30.

## Risks and limitations

- Rebased onto `main` after #423 and #424 squash-merged; the branch now targets `main` directly and Repository CI runs on it.
- A terminated match's board unmounts for everyone (the vacated seat empties the seat check); the room URL keeps showing the termination notice while the in-memory match lives (matches reset on server restart — persistence and retention remain deferred to #419), and the lobby hides the room as Abandoned. Termination latency is bounded by the 3s room poll, not the socket.
- Seat takeover by an AI (so the game can continue instead of terminating) is a stated future direction, out of scope here.

Closes #420
Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
