### PR TITLE
feat(webapp): board UX parity — round badge, hints, sticker toasts, game-over refresh

### DIFF
--- a/packages/webapp/e2e/game-flow.spec.ts
+++ b/packages/webapp/e2e/game-flow.spec.ts
@@ -205,6 +205,8 @@ test.describe('Simplified Mode — Action Flow', () => {
   // ── Scenario 1: Turn start ─────────────────────────────────────────────────
   test('Scenario 1: Alice starts her turn with 4 action tokens', async ({ page }) => {
     await expectActions(page, 'Alice', INITIAL_ACTION_TOKENS);
+    // Round badge shows the first round out of the rule-derived total.
+    await expect(page.locator('[data-testid="round-badge"]')).toHaveAttribute('data-round', '1');
   });
 
   // ── Scenario 2: Initiate a Project ────────────────────────────────────────
@@ -218,9 +220,11 @@ test.describe('Simplified Mode — Action Flow', () => {
     await expect(confirmButton(page)).toBeEnabled();
     await confirmButton(page).click();
 
-    // Verify outcome: 2 AP spent, 2 VP gained
+    // Verify outcome: 2 AP spent, 2 VP gained, and an action-result toast
+    // confirming the create (design: GpToasts).
     await expectActions(page, 'Alice', INITIAL_ACTION_TOKENS - CREATE_PROJECT_COST);
     await expectScore(page, 'Alice', CREATE_PROJECT_VP);
+    await expect(page.locator('[data-testid="toast"]').filter({ hasText: '發起' })).toBeVisible();
   });
 
   // ── Scenario 3: Recruit Talents ───────────────────────────────────────────

--- a/packages/webapp/e2e/game-flow.spec.ts
+++ b/packages/webapp/e2e/game-flow.spec.ts
@@ -222,9 +222,11 @@ test.describe('Simplified Mode — Action Flow', () => {
 
     // Verify outcome: 2 AP spent, 2 VP gained, and an action-result toast
     // confirming the create (design: GpToasts).
+    // Toast first: it self-dismisses after 5s, so assert it before the slower
+    // AP/VP polls spend that budget.
+    await expect(page.locator('[data-testid="toast"]').filter({ hasText: '發起' })).toBeVisible();
     await expectActions(page, 'Alice', INITIAL_ACTION_TOKENS - CREATE_PROJECT_COST);
     await expectScore(page, 'Alice', CREATE_PROJECT_VP);
-    await expect(page.locator('[data-testid="toast"]').filter({ hasText: '發起' })).toBeVisible();
   });
 
   // ── Scenario 3: Recruit Talents ───────────────────────────────────────────

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -474,7 +474,9 @@ body:has(.modal[open]) {
 /* Sticker toasts (design: GpToasts) — top-center stack above everything. */
 .toast-host {
   position: fixed;
-  top: 14px;
+  /* Clear the sticky table header (72px desktop, 52px compact mobile) so a
+     toast never covers the AP/VP chips it is reporting on. */
+  top: 84px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 2000;

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -438,6 +438,11 @@ body:has(.modal[open]) {
   transform: translateY(1px);
   box-shadow: 0 1px 0 var(--ink);
 }
+/* Active state for the hints ⓘ toggle. */
+.icon-btn[data-on='true'] {
+  background: var(--orange-soft);
+  border-color: var(--orange-deep);
+}
 .menu-item {
   display: flex;
   align-items: center;

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -457,3 +457,54 @@ body:has(.modal[open]) {
 .menu-item:hover {
   background: var(--paper-2);
 }
+
+/* Sticker toasts (design: GpToasts) — top-center stack above everything. */
+.toast-host {
+  position: fixed;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  pointer-events: none;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: white;
+  border: 2px solid var(--ink);
+  border-radius: 14px;
+  box-shadow: var(--shadow-sticker);
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  pointer-events: auto;
+  cursor: pointer;
+  animation: toast-in 0.22s ease;
+  max-width: min(520px, 90vw);
+}
+.toast.error {
+  border-left: 8px solid var(--orange-deep);
+  background: #fff5ef;
+}
+.toast.success {
+  border-left: 8px solid #1f7a3a;
+  background: #f0f8f1;
+}
+.toast.info {
+  border-left: 8px solid var(--teal);
+}
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -439,9 +439,17 @@ body:has(.modal[open]) {
   box-shadow: 0 1px 0 var(--ink);
 }
 /* Active state for the hints ⓘ toggle. */
-.icon-btn[data-on='true'] {
+.icon-btn[aria-pressed='true'] {
   background: var(--orange-soft);
   border-color: var(--orange-deep);
+}
+.hint {
+  font-size: 11px;
+  color: var(--ink-mute);
+  background: white;
+  border: 1.5px solid var(--paper-3);
+  border-radius: 999px;
+  padding: 3px 10px;
 }
 .menu-item {
   display: flex;

--- a/packages/webapp/src/components/BoardGame.tsx
+++ b/packages/webapp/src/components/BoardGame.tsx
@@ -66,9 +66,6 @@ const BoardInner: React.FC<GameContext> = (gameContext) => {
     prevRoundRef.current = round;
   }, [round, gameover, toast]);
 
-  const settledNamesKey = G.table.projectBoard
-    .map((slot) => (slot.card ? `${slot.id}:${slot.card.name}` : `${slot.id}:`))
-    .join('|');
   const prevSlotCardsRef = React.useRef<Map<string, string>>(new Map());
   React.useEffect(() => {
     const previous = prevSlotCardsRef.current;
@@ -84,9 +81,8 @@ const BoardInner: React.FC<GameContext> = (gameContext) => {
       });
     }
     prevSlotCardsRef.current = next;
-    // settledNamesKey encodes exactly the state this effect reads.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settledNamesKey, gameover, toast]);
+    // Safe to re-run on unrelated board updates: the map diff yields nothing.
+  }, [G.table.projectBoard, gameover, toast]);
   const isLastPlayer = ctx.playOrderPos === ctx.numPlayers - 1;
   const hasPendingDiscard = G.table.fourFreedomsPendingDiscards.length > 0;
   const outOfAP = playerID != null && (G.players[playerID]?.token?.actions ?? 1) === 0;
@@ -184,18 +180,7 @@ const BoardInner: React.FC<GameContext> = (gameContext) => {
           <span className="en-cap">Projects</span>
         </div>
         {hintsOn && (
-          <span
-            style={{
-              fontSize: 11,
-              color: 'var(--ink-mute)',
-              background: 'white',
-              border: '1.5px solid var(--paper-3)',
-              borderRadius: 999,
-              padding: '3px 10px',
-            }}
-          >
-            ⓘ 點桌上的專案來貢獻
-          </span>
+          <span className="hint">ⓘ 點桌上的專案來貢獻</span>
         )}
         <span
           className="sticker"
@@ -374,6 +359,10 @@ export function GameOverDialog({
     }
   }, [isMultiplayer, matchID, open]);
 
+  const rankedScores = Object.entries(ScoreBoardSelector.getAllPlayerPoints(G.table.scoreBoard)).sort(
+    ([, a], [, b]) => b - a,
+  );
+
   const handlePlayAgain = async () => {
     if (!savedCredentials) return;
     setIsRematching(true);
@@ -410,10 +399,10 @@ export function GameOverDialog({
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 18 }}>
-              {Object.entries(ScoreBoardSelector.getAllPlayerPoints(G.table.scoreBoard))
-                .sort(([, a], [, b]) => b - a)
-                .map(([id, points], rank) => {
+              {rankedScores.map(([id, points]) => {
                   const winner = gameover.winners.includes(id);
+                  // Competition ranking: equal scores share a rank, the next skips.
+                  const rank = rankedScores.findIndex(([, other]) => other === points) + 1;
                   return (
                     <div
                       key={id}
@@ -429,6 +418,7 @@ export function GameOverDialog({
                       }}
                     >
                       <span
+                        data-testid="result-rank"
                         aria-hidden
                         style={{
                           fontFamily: 'var(--font-en)',
@@ -438,7 +428,7 @@ export function GameOverDialog({
                           color: 'var(--ink-mute)',
                         }}
                       >
-                        {rank + 1}
+                        {rank}
                       </span>
                       <span
                         style={{
@@ -460,10 +450,10 @@ export function GameOverDialog({
                       <span style={{ fontWeight: 700, flex: 1 }}>
                         {getPlayerName(matchData, id)}
                         {id === playerID && (
-                          <span style={{ color: 'var(--orange)', marginLeft: 4, fontSize: 11 }}>YOU</span>
+                          <span style={{ color: 'var(--orange)', marginLeft: 4, fontSize: 11 }}> · YOU</span>
                         )}
                       </span>
-                      {winner && <span aria-label="優勝">👑</span>}
+                      {winner && <span role="img" aria-label="優勝">👑</span>}
                       <strong style={{ fontFamily: 'var(--font-en)' }}>{points} VP</strong>
                     </div>
                   );

--- a/packages/webapp/src/components/BoardGame.tsx
+++ b/packages/webapp/src/components/BoardGame.tsx
@@ -22,7 +22,9 @@ import { getSelectedProjectSlots } from '@/lib/reducers/projectSlotSlice';
 import { JobSlotsSelector } from '@/game/store/slice/jobSlots';
 import { RuleSelector } from '@/game/store/slice/rule';
 import { ProfessionPicker, getEligibleTargetJobNames } from './board/professionPicker';
-import { Modal, PLAYER_COLORS, StickerButton } from '@/components/design';
+import { Modal, PLAYER_COLORS, StickerButton, ToastProvider, useToast } from '@/components/design';
+import { TableSelector } from '@/game/store/slice/table';
+import { useHints } from '@/lib/useHints';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from './playerNameMap';
 import GameHeader from './board/GameHeader';
@@ -36,7 +38,13 @@ import MobileSheet from './board/MobileSheet';
 import { ScorePanel, TurnOrderPanel } from './board/SidePanels';
 import { useIsMobile } from '@/lib/useIsMobile';
 
-const Board: React.FC<GameContext> = (gameContext) => {
+const Board: React.FC<GameContext> = (gameContext) => (
+  <ToastProvider>
+    <BoardInner {...gameContext} />
+  </ToastProvider>
+);
+
+const BoardInner: React.FC<GameContext> = (gameContext) => {
   const { G, playerID, ctx, matchData } = gameContext;
   const dispatch = useAppDispatch();
   const currentAction = useAppSelector(getCurrentAction);
@@ -44,6 +52,41 @@ const Board: React.FC<GameContext> = (gameContext) => {
   const gameover = ctx.gameover as { winners: string[] } | undefined;
 
   const [showGameOver, setShowGameOver] = React.useState(true);
+  const [hintsOn, toggleHints] = useHints();
+  const toast = useToast();
+
+  // Game-event toasts derived from authoritative state transitions so every
+  // seat (and observers) see them: round start and project settlement 🎉.
+  const round = TableSelector.getRound(G.table);
+  const prevRoundRef = React.useRef(round);
+  React.useEffect(() => {
+    if (round > prevRoundRef.current && round > 1 && !gameover) {
+      toast(`🔄 第 ${round} 回合開始 — 行動格已重置。`, 'success', 4500);
+    }
+    prevRoundRef.current = round;
+  }, [round, gameover, toast]);
+
+  const settledNamesKey = G.table.projectBoard
+    .map((slot) => (slot.card ? `${slot.id}:${slot.card.name}` : `${slot.id}:`))
+    .join('|');
+  const prevSlotCardsRef = React.useRef<Map<string, string>>(new Map());
+  React.useEffect(() => {
+    const previous = prevSlotCardsRef.current;
+    const next = new Map<string, string>();
+    G.table.projectBoard.forEach((slot) => {
+      if (slot.card) next.set(slot.id, slot.card.name);
+    });
+    if (!gameover) {
+      previous.forEach((name, slotId) => {
+        if (!next.has(slotId)) {
+          toast(`🎉 「${name}」完成！貢獻者獲得影響力，工人回到玩家手上。`, 'success');
+        }
+      });
+    }
+    prevSlotCardsRef.current = next;
+    // settledNamesKey encodes exactly the state this effect reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settledNamesKey, gameover, toast]);
   const isLastPlayer = ctx.playOrderPos === ctx.numPlayers - 1;
   const hasPendingDiscard = G.table.fourFreedomsPendingDiscards.length > 0;
   const outOfAP = playerID != null && (G.players[playerID]?.token?.actions ?? 1) === 0;
@@ -140,18 +183,20 @@ const Board: React.FC<GameContext> = (gameContext) => {
           <span style={{ fontWeight: 800, fontSize: 14 }}>專案區</span>
           <span className="en-cap">Projects</span>
         </div>
-        <span
-          style={{
-            fontSize: 11,
-            color: 'var(--ink-mute)',
-            background: 'white',
-            border: '1.5px solid var(--paper-3)',
-            borderRadius: 999,
-            padding: '3px 10px',
-          }}
-        >
-          ⓘ 點桌上的專案來貢獻
-        </span>
+        {hintsOn && (
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--ink-mute)',
+              background: 'white',
+              border: '1.5px solid var(--paper-3)',
+              borderRadius: 999,
+              padding: '3px 10px',
+            }}
+          >
+            ⓘ 點桌上的專案來貢獻
+          </span>
+        )}
         <span
           className="sticker"
           data-testid="project-capacity"
@@ -207,7 +252,22 @@ const Board: React.FC<GameContext> = (gameContext) => {
     </div>
   );
 
-  const jobMarket = <JobMarket gameContext={gameContext} idle={idle} discardActive={showDiscardPanel} />;
+  const jobMarket = (
+    <JobMarket gameContext={gameContext} idle={idle} discardActive={showDiscardPanel} showHints={hintsOn} />
+  );
+
+  // #419 AC: closing the result dialog must not lose access to the result.
+  const viewResultsChip = gameover && !showGameOver && (
+    <button
+      type="button"
+      className="btn-sticker sm"
+      data-testid="view-results"
+      onClick={() => setShowGameOver(true)}
+      style={{ position: 'fixed', right: 16, bottom: 16, zIndex: 1300 }}
+    >
+      🏆 查看結果 <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>Results</span>
+    </button>
+  );
 
   return isMobile ? (
     <div
@@ -220,7 +280,7 @@ const Board: React.FC<GameContext> = (gameContext) => {
         backgroundSize: '22px 22px',
       }}
     >
-      <GameHeader gameContext={gameContext} compact />
+      <GameHeader gameContext={gameContext} compact hintsOn={hintsOn} onToggleHints={toggleHints} />
       <div
         style={{
           flex: 1,
@@ -240,6 +300,7 @@ const Board: React.FC<GameContext> = (gameContext) => {
         hand={playerID !== null && <HandPanel gameContext={gameContext} idle={idle} layout="strip" />}
       />
 
+      {viewResultsChip}
       <GameOverDialog gameContext={gameContext} open={!!gameover && showGameOver} onClose={() => setShowGameOver(false)} />
     </div>
   ) : (
@@ -253,7 +314,7 @@ const Board: React.FC<GameContext> = (gameContext) => {
         backgroundSize: '22px 22px',
       }}
     >
-      <GameHeader gameContext={gameContext} />
+      <GameHeader gameContext={gameContext} hintsOn={hintsOn} onToggleHints={toggleHints} />
 
       <div
         style={{
@@ -282,6 +343,7 @@ const Board: React.FC<GameContext> = (gameContext) => {
         </div>
       </div>
 
+      {viewResultsChip}
       <GameOverDialog gameContext={gameContext} open={!!gameover && showGameOver} onClose={() => setShowGameOver(false)} />
     </div>
   );
@@ -296,7 +358,7 @@ export function GameOverDialog({
   open: boolean;
   onClose: () => void;
 }) {
-  const { G, ctx, matchData, matchID, isMultiplayer } = gameContext;
+  const { G, ctx, matchData, matchID, isMultiplayer, playerID } = gameContext;
   const gameover = ctx.gameover as { winners: string[] } | undefined;
   const router = useRouter();
 
@@ -350,7 +412,7 @@ export function GameOverDialog({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 18 }}>
               {Object.entries(ScoreBoardSelector.getAllPlayerPoints(G.table.scoreBoard))
                 .sort(([, a], [, b]) => b - a)
-                .map(([id, points]) => {
+                .map(([id, points], rank) => {
                   const winner = gameover.winners.includes(id);
                   return (
                     <div
@@ -366,6 +428,18 @@ export function GameOverDialog({
                         boxShadow: '0 2px 0 var(--ink)',
                       }}
                     >
+                      <span
+                        aria-hidden
+                        style={{
+                          fontFamily: 'var(--font-en)',
+                          fontWeight: 800,
+                          fontSize: 14,
+                          width: 18,
+                          color: 'var(--ink-mute)',
+                        }}
+                      >
+                        {rank + 1}
+                      </span>
                       <span
                         style={{
                           width: 26,
@@ -383,7 +457,13 @@ export function GameOverDialog({
                       >
                         {getPlayerName(matchData, id)[0]}
                       </span>
-                      <span style={{ fontWeight: 700, flex: 1 }}>{getPlayerName(matchData, id)}</span>
+                      <span style={{ fontWeight: 700, flex: 1 }}>
+                        {getPlayerName(matchData, id)}
+                        {id === playerID && (
+                          <span style={{ color: 'var(--orange)', marginLeft: 4, fontSize: 11 }}>YOU</span>
+                        )}
+                      </span>
+                      {winner && <span aria-label="優勝">👑</span>}
                       <strong style={{ fontFamily: 'var(--font-en)' }}>{points} VP</strong>
                     </div>
                   );

--- a/packages/webapp/src/components/GameOverDialog.test.tsx
+++ b/packages/webapp/src/components/GameOverDialog.test.tsx
@@ -53,6 +53,11 @@ describe('GameOverDialog (#419 end-game modal)', () => {
       <GameOverDialog gameContext={makeContext()} open onClose={jest.fn()} />,
     );
     expect(getByText(/平手：Alice、Carol/)).toBeTruthy();
+    // Competition ranking: the two 12 VP players share rank 1, Bob is 3rd.
+    const ranks = Array.from(document.querySelectorAll('[data-testid="result-rank"]')).map(
+      (el) => el.textContent,
+    );
+    expect(ranks).toEqual(['1', '1', '3']);
     expect(getAllByText('12 VP')).toHaveLength(2);
     expect(getByText('9 VP')).toBeTruthy();
   });

--- a/packages/webapp/src/components/board/ContextAction.tsx
+++ b/packages/webapp/src/components/board/ContextAction.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
-import { Alert, Snackbar } from '@mui/material';
 import { GameContext } from '@/components/GameContextHelpers';
-import { useSnackbar } from '@/lib/useSnackbar';
+import { useToast } from '@/components/design';
+import { JobSlotsSelector } from '@/game/store/slice/jobSlots';
+import { ProjectBoardSelector } from '@/game/store/slice/projectBoard';
 import {
   ActionExecutionOptions,
   GENERIC_ACTION_ERROR_MESSAGE,
@@ -94,7 +95,7 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
   // moves asynchronously and INVALID_MOVE leaves state unchanged, so watch
   // ctx.numMoves after a dispatch. If it never advances, tell the player their
   // action did not happen.
-  const { snackbar, showSnackbar, closeSnackbar } = useSnackbar();
+  const toast = useToast();
   const latestMoveStateRef = React.useRef({ numMoves: ctx.numMoves ?? 0, turn: ctx.turn });
   useEffect(() => {
     latestMoveStateRef.current = { numMoves: ctx.numMoves ?? 0, turn: ctx.turn };
@@ -104,10 +105,10 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
     window.setTimeout(() => {
       const latest = latestMoveStateRef.current;
       if (latest.turn === captured.turn && latest.numMoves === captured.numMoves) {
-        showSnackbar(GENERIC_ACTION_ERROR_MESSAGE, 'error');
+        toast(GENERIC_ACTION_ERROR_MESSAGE, 'error');
       }
     }, 2000);
-  }, [ctx.numMoves, ctx.turn, showSnackbar]);
+  }, [ctx.numMoves, ctx.turn, toast]);
 
   // Entering an action enables the matching board elements; leaving it clears
   // all selections.
@@ -232,6 +233,32 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
     return isSelectionComplete(actionName!);
   };
 
+  // Action-result toast copy (design: gpApply): names come from canonical
+  // game data, costs and VP from the rule set — nothing hardcoded.
+  const actionResultMessage = (name: RegularActionName): string => {
+    const cost = RuleSelector.getActionTokenCost(G.rules, name);
+    switch (name) {
+      case 'createProject': {
+        const card = PlayersSelector.getProjectCardById(G.players, playerID!, selectionState.selectedHandProjectCards[0]);
+        const job = JobSlotsSelector.getJobCardById(G.table.jobSlots, selectionState.selectedJobSlots[0]);
+        const vp = RuleSelector.getActionVictoryPoints(G.rules, 'createProject');
+        return `🚀 發起「${card?.name ?? '專案'}」，指派 1 名${job?.name ?? '人力'}。 −${cost} AP · +${vp} VP`;
+      }
+      case 'recruit': {
+        const job = JobSlotsSelector.getJobCardById(G.table.jobSlots, selectionState.selectedJobSlots[0]);
+        const slot = ProjectBoardSelector.getBySlotId(G.table.projectBoard, selectionState.selectedProjectSlots[0]);
+        return `👥 招募${job?.name ?? '人力'}投入「${slot?.card?.name ?? '專案'}」。 −${cost} AP`;
+      }
+      case 'contributeOwnedProjects':
+      case 'contributeJoinedProjects':
+        return `✨ 貢獻 ${selectionState.totalContributionValue} 點。 −${cost} AP`;
+      case 'removeAndRefillJobs': {
+        const vp = RuleSelector.getActionVictoryPoints(G.rules, 'removeAndRefillJobs');
+        return `🔄 更換 ${selectionState.selectedJobSlots.length} 張人力卡並補滿。 −${cost} AP · +${vp} VP`;
+      }
+    }
+  };
+
   const handleConfirm = () => {
     if (currentAction === UserActionMoves.EndActionTurn) {
       typedMoves.endActionTurn();
@@ -244,7 +271,7 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
     // selection. On failure keep the selection intact and explain why.
     const failure = getPreflightFailure();
     if (failure) {
-      showSnackbar(getActionErrorMessage(failure), 'error');
+      toast(getActionErrorMessage(failure), 'error');
       return;
     }
 
@@ -275,6 +302,10 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
       case 'removeAndRefillJobs':
         typedMoves.removeAndRefillJobs(selectionState.selectedJobSlots, options);
         break;
+    }
+    toast(actionResultMessage(actionName), 'info');
+    if (overtime) {
+      toast('⏰ 加班完成 — 本輪加班 token 已用畢。', 'info', 4000);
     }
     watchForSilentRejection();
     dispatch(resetAction());
@@ -358,7 +389,7 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
           icon: '🏁',
           title: '結束這回合？',
           en: 'End your turn',
-          hint: '剩下的行動點會被放棄。',
+          hint: `剩下的 ${actionTokens} 點行動點會被放棄。`,
           tone: 'var(--ink)',
           cta: '確認結束',
         };
@@ -593,19 +624,6 @@ export default function ContextAction({ gameContext }: { gameContext: GameContex
         </button>
       )}
 
-      {/* Error toast: click-time validation failures and the generic
-          unexpected-rejection fallback. Single-slot, so repeats replace
-          rather than queue. */}
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={closeSnackbar}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        <Alert severity={snackbar.severity} onClose={closeSnackbar} data-testid="action-error-toast">
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </div>
   );
 }

--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -138,9 +138,9 @@ export default function GameHeader({
                 <button
                   type="button"
                   className="icon-btn"
-                  data-on={hintsOn ? 'true' : undefined}
                   data-testid="hints-toggle"
                   onClick={onToggleHints}
+                  aria-label={hintsOn ? '隱藏操作提示 · Hide hints' : '顯示操作提示 · Show hints'}
                   title={hintsOn ? '隱藏操作提示 · Hide hints' : '顯示操作提示 · Show hints'}
                   aria-pressed={hintsOn}
                 >

--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -6,17 +6,23 @@ import { PlayersSelector } from '@/game/store/slice/players';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from '@/components/playerNameMap';
 import ExitDialog from './ExitDialog';
+import RoundBadge from './RoundBadge';
 
-/** Sticky table header: shared app shell + per-player status chips (design: GameHeader).
- *  `compact` (mobile): only the seated player's chip + a ⋯ menu holding the
- *  secondary actions; desktop shows every chip and a Leave button. Leaving
- *  always goes through the explicit exit-choice dialog (#420). */
+/** Sticky table header: shared app shell + round badge + per-player status
+ *  chips (design: GameHeader). `compact` (mobile): only the seated player's
+ *  chip + a ⋯ menu holding the secondary actions; desktop shows every chip,
+ *  the hints ⓘ toggle, and a Leave button. Leaving always goes through the
+ *  explicit exit-choice dialog (#420). */
 export default function GameHeader({
   gameContext,
   compact = false,
+  hintsOn,
+  onToggleHints,
 }: {
   gameContext: GameContext;
   compact?: boolean;
+  hintsOn?: boolean;
+  onToggleHints?: () => void;
 }) {
   const { G, ctx, playerID, matchData, matchID } = gameContext;
   const [exitOpen, setExitOpen] = React.useState(false);
@@ -39,6 +45,7 @@ export default function GameHeader({
       compact={compact}
       right={
         <>
+          <RoundBadge gameContext={gameContext} compact={compact} />
           <div
             style={{
               display: 'flex',
@@ -104,6 +111,20 @@ export default function GameHeader({
                       minWidth: 190,
                     }}
                   >
+                    {onToggleHints && (
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="menu-item"
+                        data-testid="menu-hints"
+                        onClick={() => {
+                          onToggleHints();
+                          setMenuOpen(false);
+                        }}
+                      >
+                        ⓘ {hintsOn ? '隱藏操作提示' : '顯示操作提示'}
+                      </button>
+                    )}
                     <button type="button" role="menuitem" className="menu-item" data-testid="menu-leave" onClick={openExit}>
                       🚪 離開遊戲 <span className="tag-en">Leave</span>
                     </button>
@@ -112,15 +133,29 @@ export default function GameHeader({
               )}
             </div>
           ) : (
-            <button
-              type="button"
-              className="btn-sticker sm ghost"
-              style={{ flexShrink: 0 }}
-              data-testid="header-leave"
-              onClick={openExit}
-            >
-              離開 <span className="tag-en">Leave</span>
-            </button>
+            <div style={{ display: 'flex', gap: 6, flexShrink: 0, alignItems: 'center' }}>
+              {onToggleHints && (
+                <button
+                  type="button"
+                  className="icon-btn"
+                  data-on={hintsOn ? 'true' : undefined}
+                  data-testid="hints-toggle"
+                  onClick={onToggleHints}
+                  title={hintsOn ? '隱藏操作提示 · Hide hints' : '顯示操作提示 · Show hints'}
+                  aria-pressed={hintsOn}
+                >
+                  ⓘ
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn-sticker sm ghost"
+                data-testid="header-leave"
+                onClick={openExit}
+              >
+                離開 <span className="tag-en">Leave</span>
+              </button>
+            </div>
           )}
           {/* Mounted lazily: ExitDialog uses the app router, which only exists
               once the user can actually open it. */}

--- a/packages/webapp/src/components/board/JobMarket.tsx
+++ b/packages/webapp/src/components/board/JobMarket.tsx
@@ -22,10 +22,12 @@ export default function JobMarket({
   gameContext,
   idle,
   discardActive,
+  showHints = true,
 }: {
   gameContext: GameContext;
   idle: boolean;
   discardActive: boolean;
+  showHints?: boolean;
 }) {
   const { G } = gameContext;
   const dispatch = useAppDispatch();
@@ -52,18 +54,20 @@ export default function JobMarket({
           <span style={{ fontWeight: 800, fontSize: 14 }}>人力市場</span>
           <span className="en-cap">Job market · {G.table.jobSlots.length} cards</span>
         </div>
-        <span
-          style={{
-            fontSize: 11,
-            color: 'var(--ink-mute)',
-            background: 'white',
-            border: '1.5px solid var(--paper-3)',
-            borderRadius: 999,
-            padding: '3px 10px',
-          }}
-        >
-          ⓘ 點人力卡招募到你的專案
-        </span>
+        {showHints && (
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--ink-mute)',
+              background: 'white',
+              border: '1.5px solid var(--paper-3)',
+              borderRadius: 999,
+              padding: '3px 10px',
+            }}
+          >
+            ⓘ 點人力卡招募到你的專案
+          </span>
+        )}
         {idle && (
           <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
             <button

--- a/packages/webapp/src/components/board/JobMarket.tsx
+++ b/packages/webapp/src/components/board/JobMarket.tsx
@@ -55,18 +55,7 @@ export default function JobMarket({
           <span className="en-cap">Job market · {G.table.jobSlots.length} cards</span>
         </div>
         {showHints && (
-          <span
-            style={{
-              fontSize: 11,
-              color: 'var(--ink-mute)',
-              background: 'white',
-              border: '1.5px solid var(--paper-3)',
-              borderRadius: 999,
-              padding: '3px 10px',
-            }}
-          >
-            ⓘ 點人力卡招募到你的專案
-          </span>
+          <span className="hint">ⓘ 點人力卡招募到你的專案</span>
         )}
         {idle && (
           <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>

--- a/packages/webapp/src/components/board/RoundBadge.test.tsx
+++ b/packages/webapp/src/components/board/RoundBadge.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import RoundBadge from './RoundBadge';
+import { GameContext } from '@/components/GameContextHelpers';
+
+const contextWith = (round: number | undefined, numNonEndGameEventCards = 5) =>
+  ({
+    G: {
+      table: { round },
+      rules: { numNonEndGameEventCards },
+    },
+  }) as unknown as GameContext;
+
+describe('RoundBadge', () => {
+  it('renders 第 X / Y 回合 from table round and rule-derived total', () => {
+    const { getByTestId } = render(<RoundBadge gameContext={contextWith(2, 5)} />);
+    const badge = getByTestId('round-badge');
+    expect(badge.getAttribute('data-round')).toBe('2');
+    // Total = non-end-game event cards + the end-game round.
+    expect(badge.textContent).toContain('第 2');
+    expect(badge.textContent).toContain('/ 6 回合');
+  });
+
+  it('hides before the first round and on fixtures without state', () => {
+    expect(render(<RoundBadge gameContext={contextWith(0)} />).queryByTestId('round-badge')).toBeNull();
+    expect(
+      render(<RoundBadge gameContext={{ G: { table: {} } } as unknown as GameContext} />).queryByTestId('round-badge'),
+    ).toBeNull();
+  });
+});

--- a/packages/webapp/src/components/board/RoundBadge.tsx
+++ b/packages/webapp/src/components/board/RoundBadge.tsx
@@ -22,17 +22,8 @@ export default function RoundBadge({
       title="目前回合 · Current round"
       data-testid="round-badge"
       data-round={round}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 6,
-        background: 'white',
-        border: '1.5px solid var(--ink)',
-        borderRadius: 999,
-        boxShadow: '0 2px 0 var(--ink)',
-        padding: compact ? '3px 10px' : '4px 12px',
-        flexShrink: 0,
-      }}
+      className="sticker"
+      style={{ padding: compact ? '3px 10px' : '4px 12px', flexShrink: 0 }}
     >
       <span style={{ fontSize: compact ? 11 : 12, fontWeight: 800 }}>
         第 {round}

--- a/packages/webapp/src/components/board/RoundBadge.tsx
+++ b/packages/webapp/src/components/board/RoundBadge.tsx
@@ -12,7 +12,7 @@ export default function RoundBadge({
   compact?: boolean;
 }) {
   const { G } = gameContext;
-  if (!G.table || !G.rules) return null;
+  if (!G.table) return null;
   const round = TableSelector.getRound(G.table);
   if (!round || round < 1) return null;
   const totalRounds = RuleSelector.getTotalRounds(G.rules);

--- a/packages/webapp/src/components/board/RoundBadge.tsx
+++ b/packages/webapp/src/components/board/RoundBadge.tsx
@@ -1,0 +1,44 @@
+import { GameContext } from '@/components/GameContextHelpers';
+import { RuleSelector } from '@/game/store/slice/rule';
+import { TableSelector } from '@/game/store/slice/table';
+
+/** 第 X / Y 回合 pill (design: GpRoundBadge). Hidden until the first event
+ *  card starts round 1 (and in fixtures without table/rule state). */
+export default function RoundBadge({
+  gameContext,
+  compact = false,
+}: {
+  gameContext: GameContext;
+  compact?: boolean;
+}) {
+  const { G } = gameContext;
+  if (!G.table || !G.rules) return null;
+  const round = TableSelector.getRound(G.table);
+  if (!round || round < 1) return null;
+  const totalRounds = RuleSelector.getTotalRounds(G.rules);
+
+  return (
+    <div
+      title="目前回合 · Current round"
+      data-testid="round-badge"
+      data-round={round}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        background: 'white',
+        border: '1.5px solid var(--ink)',
+        borderRadius: 999,
+        boxShadow: '0 2px 0 var(--ink)',
+        padding: compact ? '3px 10px' : '4px 12px',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ fontSize: compact ? 11 : 12, fontWeight: 800 }}>
+        第 {round}
+        <span style={{ color: 'var(--ink-mute)', fontWeight: 500 }}> / {totalRounds}</span> 回合
+      </span>
+      {!compact && <span className="tag-en">Round {round} of {totalRounds}</span>}
+    </div>
+  );
+}

--- a/packages/webapp/src/components/design/Toast.test.tsx
+++ b/packages/webapp/src/components/design/Toast.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { ToastProvider, useToast } from './Toast';
+
+function Fire({ label, message, kind }: { label: string; message: string; kind?: 'error' | 'success' | 'info' }) {
+  const toast = useToast();
+  return (
+    <button type="button" onClick={() => toast(message, kind)}>
+      {label}
+    </button>
+  );
+}
+
+describe('sticker toast system', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('shows a toast with its kind and dismisses on click', () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <ToastProvider>
+        <Fire label="fire" message="貢獻 3 點" kind="success" />
+      </ToastProvider>,
+    );
+    fireEvent.click(getByText('fire'));
+    const toast = getByTestId('toast');
+    expect(toast.getAttribute('data-kind')).toBe('success');
+    expect(toast.textContent).toContain('貢獻 3 點');
+    fireEvent.click(toast);
+    expect(queryByTestId('toast')).toBeNull();
+  });
+
+  it('auto-dismisses after the duration', () => {
+    const { getByText, queryByTestId } = render(
+      <ToastProvider>
+        <Fire label="fire" message="msg" />
+      </ToastProvider>,
+    );
+    fireEvent.click(getByText('fire'));
+    expect(queryByTestId('toast')).not.toBeNull();
+    act(() => {
+      jest.advanceTimersByTime(5100);
+    });
+    expect(queryByTestId('toast')).toBeNull();
+  });
+
+  it('caps the visible stack at 4, dropping the oldest', () => {
+    const { getByText, getAllByTestId } = render(
+      <ToastProvider>
+        <Fire label="fire" message="msg" />
+      </ToastProvider>,
+    );
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(getByText('fire'));
+    }
+    expect(getAllByTestId('toast')).toHaveLength(4);
+  });
+});

--- a/packages/webapp/src/components/design/Toast.test.tsx
+++ b/packages/webapp/src/components/design/Toast.test.tsx
@@ -46,6 +46,22 @@ describe('sticker toast system', () => {
     expect(queryByTestId('toast')).toBeNull();
   });
 
+  it('only failures interrupt the screen reader', () => {
+    const { getByText, getAllByTestId } = render(
+      <ToastProvider>
+        <Fire label="err" message="failed" kind="error" />
+        <Fire label="ok" message="done" kind="success" />
+        <Fire label="fyi" message="note" kind="info" />
+      </ToastProvider>,
+    );
+    fireEvent.click(getByText('err'));
+    fireEvent.click(getByText('ok'));
+    fireEvent.click(getByText('fyi'));
+    const roles = getAllByTestId('toast').map((t) => t.getAttribute('role'));
+    // Assertive only for errors; progress updates queue politely.
+    expect(roles).toEqual(['alert', 'status', 'status']);
+  });
+
   it('caps the visible stack at 4, dropping the oldest', () => {
     const { getByText, getAllByTestId } = render(
       <ToastProvider>

--- a/packages/webapp/src/components/design/Toast.tsx
+++ b/packages/webapp/src/components/design/Toast.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 export type ToastKind = 'error' | 'success' | 'info';
 
-export interface ToastItem {
+interface ToastItem {
   id: number;
   message: string;
   kind: ToastKind;
@@ -70,7 +70,8 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           <div
             key={item.id}
             className={`toast ${item.kind}`}
-            role="alert"
+            // Only failures interrupt the screen reader; progress updates queue politely.
+            role={item.kind === 'error' ? 'alert' : 'status'}
             data-testid="toast"
             data-kind={item.kind}
             onClick={() => dismiss(item.id)}

--- a/packages/webapp/src/components/design/Toast.tsx
+++ b/packages/webapp/src/components/design/Toast.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React from 'react';
+
+/**
+ * Sticker toast system (design: GpToasts). Top-center stack, newest last,
+ * capped at 4 visible; every toast auto-dismisses and can be tapped away.
+ * Kinds map to the prototype's error/success/info left-border treatments.
+ */
+
+export type ToastKind = 'error' | 'success' | 'info';
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  kind: ToastKind;
+}
+
+type ToastFn = (message: string, kind?: ToastKind, durationMs?: number) => void;
+
+const ToastContext = React.createContext<ToastFn | null>(null);
+
+const MAX_VISIBLE = 4;
+const DEFAULT_DURATION_MS = 5000;
+
+export function useToast(): ToastFn {
+  const toast = React.useContext(ToastContext);
+  if (!toast) {
+    throw new Error('useToast must be used inside <ToastProvider>');
+  }
+  return toast;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<ToastItem[]>([]);
+  const nextIdRef = React.useRef(0);
+  const timersRef = React.useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
+  React.useEffect(() => {
+    const timers = timersRef.current;
+    return () => timers.forEach((timer) => clearTimeout(timer));
+  }, []);
+
+  const dismiss = React.useCallback((id: number) => {
+    setToasts((current) => current.filter((item) => item.id !== id));
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const toast = React.useCallback<ToastFn>(
+    (message, kind = 'info', durationMs = DEFAULT_DURATION_MS) => {
+      const id = ++nextIdRef.current;
+      setToasts((current) => [...current.slice(-(MAX_VISIBLE - 1)), { id, message, kind }]);
+      timersRef.current.set(
+        id,
+        setTimeout(() => dismiss(id), durationMs),
+      );
+    },
+    [dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={toast}>
+      {children}
+      <div className="toast-host" data-testid="toast-host">
+        {toasts.map((item) => (
+          <div
+            key={item.id}
+            className={`toast ${item.kind}`}
+            role="alert"
+            data-testid="toast"
+            data-kind={item.kind}
+            onClick={() => dismiss(item.id)}
+          >
+            <span aria-hidden>{item.kind === 'error' ? '⚠' : item.kind === 'success' ? '✅' : 'ⓘ'}</span>
+            <span>{item.message}</span>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/packages/webapp/src/components/design/Toast.tsx
+++ b/packages/webapp/src/components/design/Toast.tsx
@@ -34,30 +34,17 @@ export function useToast(): ToastFn {
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = React.useState<ToastItem[]>([]);
   const nextIdRef = React.useRef(0);
-  const timersRef = React.useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
 
-  React.useEffect(() => {
-    const timers = timersRef.current;
-    return () => timers.forEach((timer) => clearTimeout(timer));
-  }, []);
-
+  // A timer that outlives its toast is a no-op: dismiss filters by id.
   const dismiss = React.useCallback((id: number) => {
     setToasts((current) => current.filter((item) => item.id !== id));
-    const timer = timersRef.current.get(id);
-    if (timer) {
-      clearTimeout(timer);
-      timersRef.current.delete(id);
-    }
   }, []);
 
   const toast = React.useCallback<ToastFn>(
     (message, kind = 'info', durationMs = DEFAULT_DURATION_MS) => {
       const id = ++nextIdRef.current;
       setToasts((current) => [...current.slice(-(MAX_VISIBLE - 1)), { id, message, kind }]);
-      timersRef.current.set(
-        id,
-        setTimeout(() => dismiss(id), durationMs),
-      );
+      setTimeout(() => dismiss(id), durationMs);
     },
     [dismiss],
   );
@@ -65,7 +52,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={toast}>
       {children}
-      <div className="toast-host" data-testid="toast-host">
+      <div className="toast-host">
         {toasts.map((item) => (
           <div
             key={item.id}

--- a/packages/webapp/src/components/design/index.ts
+++ b/packages/webapp/src/components/design/index.ts
@@ -4,6 +4,8 @@ export { default as StickerButton } from './StickerButton';
 export { default as Modal } from './Modal';
 export { default as PaperCard } from './PaperCard';
 export { default as CharacterAvatar } from './CharacterAvatar';
+export { ToastProvider, useToast } from './Toast';
+export type { ToastKind } from './Toast';
 export {
   JOB_META,
   PROJECT_TYPES,

--- a/packages/webapp/src/components/design/index.ts
+++ b/packages/webapp/src/components/design/index.ts
@@ -5,7 +5,6 @@ export { default as Modal } from './Modal';
 export { default as PaperCard } from './PaperCard';
 export { default as CharacterAvatar } from './CharacterAvatar';
 export { ToastProvider, useToast } from './Toast';
-export type { ToastKind } from './Toast';
 export {
   JOB_META,
   PROJECT_TYPES,

--- a/packages/webapp/src/game/store/slice/table.ts
+++ b/packages/webapp/src/game/store/slice/table.ts
@@ -48,7 +48,8 @@ const getCurrentEvent = (state: Table): EventCard | null => {
 }
 
 const getRound = (state: Table): number => {
-  return state.round;
+  // Fallback for state persisted before the round counter existed.
+  return state.round ?? 0;
 }
 
 const TableSlice = {

--- a/packages/webapp/src/lib/useHints.ts
+++ b/packages/webapp/src/lib/useHints.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+
+const HINTS_STORAGE_KEY = 'open-star-ter-village.hints';
+
+/**
+ * Operation-hint visibility (design: GpHeader ⓘ toggle). On by default for
+ * new players; the choice persists per browser.
+ */
+export function useHints(): [boolean, () => void] {
+  const [hintsOn, setHintsOn] = React.useState(true);
+
+  React.useEffect(() => {
+    if (localStorage.getItem(HINTS_STORAGE_KEY) === 'off') {
+      setHintsOn(false);
+    }
+  }, []);
+
+  const toggleHints = React.useCallback(() => {
+    setHintsOn((current) => {
+      const next = !current;
+      localStorage.setItem(HINTS_STORAGE_KEY, next ? 'on' : 'off');
+      return next;
+    });
+  }, []);
+
+  return [hintsOn, toggleHints];
+}

--- a/packages/webapp/src/lib/useHints.ts
+++ b/packages/webapp/src/lib/useHints.ts
@@ -17,13 +17,13 @@ export function useHints(): [boolean, () => void] {
     }
   }, []);
 
+  // The write stays outside the state updater: React requires updaters to be
+  // pure and re-invokes them under StrictMode and render restarts.
   const toggleHints = React.useCallback(() => {
-    setHintsOn((current) => {
-      const next = !current;
-      localStorage.setItem(HINTS_STORAGE_KEY, next ? 'on' : 'off');
-      return next;
-    });
-  }, []);
+    const next = !hintsOn;
+    localStorage.setItem(HINTS_STORAGE_KEY, next ? 'on' : 'off');
+    setHintsOn(next);
+  }, [hintsOn]);
 
   return [hintsOn, toggleHints];
 }


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Closes the remaining in-game UX gaps against the MVP prototype: a header round badge (第 X / Y 回合), a persistable hints toggle, the prototype's sticker toast system replacing the MUI snackbar (with action-result / settlement / round-start feedback), and the game-over dialog refresh (ranked rows with 👑 and YOU, plus a persistent 查看結果 chip so closing the dialog never loses the result — a #419 acceptance criterion).

## Changes

- **RoundBadge** (`board/RoundBadge.tsx`, design GpRoundBadge): reads `G.table.round` (PR #423's counter) and the rule-derived total (`RuleSelector.getTotalRounds`); hidden until round 1 and on legacy states (defensive `getRound ?? 0`).
- **Hints** (`lib/useHints.ts`): on by default, persisted per browser (`open-star-ter-village.hints`); desktop ⓘ icon toggle in the header, ⋯ menu entry on mobile; gates the 專案區/人力市場 hint pills.
- **Sticker toasts** (`design/Toast.tsx` + globals.css, design GpToasts): top-center stack, error/success/info kinds, max 4 visible, 5s auto + tap dismiss, `role="alert"`. ContextAction now uses it for click-time validation failures and the silent-rejection fallback (MUI Snackbar removed there); confirm fires bilingual action-result toasts with names/AP/VP from canonical game data (🚀/👥/✨/🔄, ⏰ on overtime); Board derives 🎉 settlement toasts (slot card cleared) and 🔄 round-start toasts from authoritative state transitions so every seat and observer sees them.
- **GameOverDialog refresh**: rank numbers (competition ranking — tied players share a rank), 👑 on winners (`role="img"`), YOU marker; the 再玩一次/回大廳 actions from PR #424 retained; when closed, a fixed 🏆 查看結果 chip reopens it.
- **End-turn copy** now states the concrete forfeit: 剩下的 {X} 點行動點會被放棄。
- **Toast placement**: the host clears the sticky table header (`top: 84px`) so a toast never covers the AP/VP chips it is reporting on — visible once #432 unified the game and dev views.

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:** <!-- Required when "Evidence not applicable" is selected. -->

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Round badge shows 第 1 / 6 回合 alongside chips; hint pills visible by default | Unified game view, idle board (desktop 1280×1150) | ![board](https://raw.githubusercontent.com/ocftw/open-star-ter-village/90ce24e45c3afe6252c2ff20f228d2e461d177cb/evidence/1-board-round-badge-hints.png) |
| ⓘ toggle hides the hint pills and persists | Toggle off → pills gone | ![hints off](https://raw.githubusercontent.com/ocftw/open-star-ter-village/90ce24e45c3afe6252c2ff20f228d2e461d177cb/evidence/2-hints-off.png) |
| Confirming an action fires a bilingual sticker action-result toast | Create project via card flow | ![toast](https://raw.githubusercontent.com/ocftw/open-star-ter-village/90ce24e45c3afe6252c2ff20f228d2e461d177cb/evidence/3-action-toast.png) |
| Mobile ⋯ menu gains the hints entry | Unified game view at 390×844 | ![mobile](https://raw.githubusercontent.com/ocftw/open-star-ter-village/90ce24e45c3afe6252c2ff20f228d2e461d177cb/evidence/4-mobile-menu-hints.png) |
| Toast semantics: kind styling, tap dismiss, auto dismiss, 4-cap | `Toast.test.tsx` (4 tests, incl. assertive-only-on-error) | Jest 153/153 pass at d4a4dba7 |
| Round badge rendering + hidden states | `RoundBadge.test.tsx` (2 tests) | Jest 153/153 pass at d4a4dba7 |
| Round badge + create toast asserted end-to-end | `game-flow.spec.ts` Scenarios 1–2 assertions | Playwright 37/37 pass at d4a4dba7 |
| Tied players share a rank instead of being numbered sequentially | `GameOverDialog.test.tsx` tie fixture (12/9/12) asserts ranks `['1','1','3']`; mutation-checked — reverting to index-based ranking fails it | Jest 153/153 pass at d4a4dba7 |
| Game-over refresh (👑/YOU/查看結果 chip) and settlement/round toasts | Code-reviewed; exercised in the post-merge full-game production pass (a full 6-round game is impractical in CI) | Deploy smoke per `skills/webapp-deploy-smoke-test/SKILL.md` |

## Risks and limitations

- Rebased onto `main` after #432 (unified game/dev view) — evidence recaptured on the unified view, e2e now uses main's `devTools` helper. Earlier rebases followed #423/#424/#425; now targets `main` directly. Local gate at 20e97ff5: lint, tsc (app + server), jest 153/153, Playwright 37/37.
- Action-result toasts fire at confirm time after client preflight; a server-side rejection still surfaces through the 2s silent-rejection watchdog (unchanged behavior).
- Settlement toasts trigger on slot-card clearing; at game end they are suppressed in favor of the result dialog.
- Toasts render below an open dialog: the native `<dialog>` top layer outranks any `z-index`, so a toast fired while the exit or terminated-match dialog is open is hidden behind its backdrop (verified with `document.elementFromPoint`) and, because `showModal()` makes the rest of the page inert, is not announced to assistive tech either. Affects only that window; game-over toasts are already suppressed. Fixing it needs the Popover API with per-batch re-promotion — not worth the machinery for a transient auto-dismissing message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




