### PR TITLE
feat(webapp): in-game bug report with state snapshot and prefilled issue

### DIFF
--- a/packages/webapp/e2e/game-flow.spec.ts
+++ b/packages/webapp/e2e/game-flow.spec.ts
@@ -367,6 +367,31 @@ test.describe('Simplified Mode — Action Flow', () => {
     await expect(page.locator('[data-testid="overtime-token"]')).not.toHaveAttribute('data-available', 'true');
   });
 
+  // ── Scenario 9b: in-game bug report ───────────────────────────────────────
+  test('Scenario 9b: bug report dialog — snapshot, minimize, prefilled issue link', async ({ page }) => {
+    await page.locator('[data-testid="bug-report-open"]').click();
+    const dialog = page.locator('[data-testid="bug-report-dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(page.locator('[data-testid="bug-report-snapshot"]')).toContainText('回合 Round: 1/6');
+
+    // Draft + prefilled GitHub link carrying the title and bug label.
+    await page.locator('[data-testid="bug-report-description"]').fill('測試回報');
+    const href = await page.locator('[data-testid="bug-report-open-issue"]').getAttribute('href');
+    expect(href).toContain('issues/new');
+    const issueUrl = new URL(href!);
+    expect(issueUrl.searchParams.get('labels')).toBe('bug');
+    expect(issueUrl.searchParams.get('title')).toBe('[bug] 測試回報');
+
+    // Minimize → board stays interactive; restore keeps the draft.
+    await page.locator('[data-testid="bug-report-minimize"]').click();
+    await expect(dialog).toHaveCount(0);
+    await expect(contextAction(page)).toHaveAttribute('data-mode', 'idle');
+    await page.locator('[data-testid="bug-report-chip"]').click();
+    await expect(page.locator('[data-testid="bug-report-description"]')).toHaveValue('測試回報');
+    await page.locator('[data-testid="bug-report-close"]').click();
+    await expect(page.locator('[data-testid="bug-report-dialog"]')).toHaveCount(0);
+  });
+
   // ── Scenario 10: contributeJoinedProjects ─────────────────────────────────
   test('Scenario 10: contributeJoinedProjects — recruit on another player\'s project and contribute', async ({ page }) => {
     // === Round 1 ===

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -32,6 +32,7 @@
     "@sentry/nextjs": "^10.53.1",
     "@sentry/node": "^10.53.1",
     "boardgame.io": "^0.50.2",
+    "html-to-image": "^1.11.13",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/webapp/src/components/board/BugReportDialog.test.tsx
+++ b/packages/webapp/src/components/board/BugReportDialog.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import BugReportDialog, { buildIssueUrl, buildStateSnapshot } from './BugReportDialog';
+import { makeStore } from '@/lib/store';
+import { GameContext } from '@/components/GameContextHelpers';
+
+const toBlobMock = jest.fn();
+jest.mock('html-to-image', () => ({
+  toBlob: (...args: unknown[]) => toBlobMock(...args),
+}));
+
+const gameContext = {
+  G: {
+    players: {
+      '0': { token: { workers: 12, actions: 3, overtime: 1 } },
+      '1': { token: { workers: 11, actions: 4, overtime: 0 } },
+    },
+    table: {
+      scoreBoard: { '0': 2, '1': 5 },
+      round: 2,
+      actionSlots: {
+        createProject: { isOccupied: true },
+        recruit: { isOccupied: false },
+        contributeOwnedProjects: { isOccupied: false },
+        contributeJoinedProjects: { isOccupied: false },
+        removeAndRefillJobs: { isOccupied: false },
+      },
+    },
+    rules: { numNonEndGameEventCards: 5 },
+  },
+  ctx: { currentPlayer: '1' },
+  playerID: '0',
+  matchID: 'room-9',
+  matchData: undefined,
+} as unknown as GameContext;
+
+const renderDialog = (state: 'open' | 'minimized' = 'open') => {
+  const onMinimize = jest.fn();
+  const onRestore = jest.fn();
+  const onClose = jest.fn();
+  const utils = render(
+    <Provider store={makeStore()}>
+      <BugReportDialog
+        gameContext={gameContext}
+        state={state}
+        onMinimize={onMinimize}
+        onRestore={onRestore}
+        onClose={onClose}
+      />
+    </Provider>,
+  );
+  return { ...utils, onMinimize, onRestore, onClose };
+};
+
+describe('state snapshot + issue URL', () => {
+  it('captures round, players, occupied slots, seat, and UA', () => {
+    const snapshot = buildStateSnapshot(gameContext, 'recruit');
+    expect(snapshot).toContain('回合 Round: 2/6');
+    expect(snapshot).toContain('Action in progress: recruit');
+    expect(snapshot).toContain('AP: Alice 3 · Bob 4');
+    expect(snapshot).toContain('VP: Alice 2 · Bob 5');
+    expect(snapshot).toContain('加班 Overtime: Alice 1 · Bob 0');
+    expect(snapshot).toContain('Action slots used: createProject');
+    expect(snapshot).toContain('Match: room-9 · seat 0');
+    expect(snapshot).toContain('UA: ');
+  });
+
+  it('prefills title from the first description line with the bug label', () => {
+    const url = new URL(buildIssueUrl('招募沒反應\n第二行', 'SNAP'));
+    expect(url.origin + url.pathname).toBe('https://github.com/ocftw/open-star-ter-village/issues/new');
+    expect(url.searchParams.get('title')).toBe('[bug] 招募沒反應');
+    expect(url.searchParams.get('labels')).toBe('bug');
+    expect(url.searchParams.get('body')).toContain('SNAP');
+    expect(url.searchParams.get('body')).toContain('請將截圖直接貼上');
+  });
+
+  it('falls back to a generic title when the description is empty', () => {
+    const url = new URL(buildIssueUrl('', 'SNAP'));
+    expect(url.searchParams.get('title')).toBe('[bug] 遊戲問題回報');
+  });
+});
+
+describe('BugReportDialog', () => {
+  beforeEach(() => toBlobMock.mockReset());
+
+  it('shows the snapshot and a live issue link', () => {
+    const { getByTestId } = renderDialog();
+    expect(getByTestId('bug-report-snapshot').textContent).toContain('Match: room-9');
+    const href = (getByTestId('bug-report-open-issue') as HTMLAnchorElement).href;
+    expect(href).toContain('issues/new');
+    expect(href).toContain('labels=bug');
+  });
+
+  it('minimized chip keeps the component mounted and restores on tap', () => {
+    const { getByTestId, onMinimize, onRestore, rerender, queryByTestId } = renderDialog();
+    fireEvent.change(getByTestId('bug-report-description'), { target: { value: 'draft text' } });
+    fireEvent.click(getByTestId('bug-report-minimize'));
+    expect(onMinimize).toHaveBeenCalled();
+
+    rerender(
+      <Provider store={makeStore()}>
+        <BugReportDialog
+          gameContext={gameContext}
+          state="minimized"
+          onMinimize={onMinimize}
+          onRestore={onRestore}
+          onClose={jest.fn()}
+        />
+      </Provider>,
+    );
+    expect(queryByTestId('bug-report-dialog')).toBeNull();
+    fireEvent.click(getByTestId('bug-report-chip'));
+    expect(onRestore).toHaveBeenCalled();
+
+    rerender(
+      <Provider store={makeStore()}>
+        <BugReportDialog
+          gameContext={gameContext}
+          state="open"
+          onMinimize={onMinimize}
+          onRestore={onRestore}
+          onClose={jest.fn()}
+        />
+      </Provider>,
+    );
+    // Same mounted component — the draft survives the minimize/restore cycle.
+    expect((getByTestId('bug-report-description') as HTMLTextAreaElement).value).toBe('draft text');
+  });
+
+  it('copies a board screenshot to the clipboard when supported', async () => {
+    toBlobMock.mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
+    const write = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { write } });
+    (globalThis as Record<string, unknown>).ClipboardItem = class {
+      constructor(public items: Record<string, Blob>) {}
+    };
+
+    const { getByTestId } = renderDialog();
+    fireEvent.click(getByTestId('bug-report-screenshot'));
+    await waitFor(() =>
+      expect(getByTestId('bug-report-screenshot-status').textContent).toContain('截圖已複製'),
+    );
+    expect(write).toHaveBeenCalled();
+  });
+
+  it('falls back to manual-screenshot guidance when capture fails', async () => {
+    toBlobMock.mockRejectedValue(new Error('no canvas'));
+    const { getByTestId } = renderDialog();
+    fireEvent.click(getByTestId('bug-report-screenshot'));
+    await waitFor(() =>
+      expect(getByTestId('bug-report-screenshot-status').textContent).toContain('無法自動複製'),
+    );
+  });
+});

--- a/packages/webapp/src/components/board/BugReportDialog.tsx
+++ b/packages/webapp/src/components/board/BugReportDialog.tsx
@@ -1,0 +1,307 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { toBlob } from 'html-to-image';
+import { GameContext } from '@/components/GameContextHelpers';
+import { StickerButton } from '@/components/design';
+import { useAppSelector } from '@/lib/hooks';
+import { getCurrentAction } from '@/lib/reducers/actionStepSlice';
+import { PlayersSelector } from '@/game/store/slice/players';
+import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
+import { ActionSlotSelector } from '@/game/store/slice/actionSlot';
+import { TableSelector } from '@/game/store/slice/table';
+import { RuleSelector } from '@/game/store/slice/rule';
+import { getPlayerName } from '@/components/playerNameMap';
+import { ActionMoveName } from '@/game/core/stage/action/move/type';
+
+const ISSUES_NEW_URL = 'https://github.com/ocftw/open-star-ter-village/issues/new';
+
+export type BugReportState = 'closed' | 'open' | 'minimized';
+
+type ScreenshotStatus = 'idle' | 'copying' | 'copied' | 'manual';
+
+/** Auto game-state snapshot embedded in the prefilled issue (design: GpBugDialog). */
+export function buildStateSnapshot(gameContext: GameContext, currentAction: string | null): string {
+  const { G, ctx, playerID, matchData, matchID } = gameContext;
+  const playerIDs = Object.keys(G.players);
+  const nameOf = (id: string) => getPlayerName(matchData, id);
+  const perPlayer = (value: (id: string) => number | string) =>
+    playerIDs.map((id) => `${nameOf(id)} ${value(id)}`).join(' · ');
+  const occupiedSlots = (Object.keys(G.table.actionSlots) as ActionMoveName[]).filter((name) =>
+    ActionSlotSelector.isOccupied(G.table.actionSlots[name]),
+  );
+
+  return [
+    `回合 Round: ${TableSelector.getRound(G.table)}/${G.rules ? RuleSelector.getTotalRounds(G.rules) : '?'}`,
+    `現在玩家 Current player: ${nameOf(ctx.currentPlayer)}`,
+    `進行中行動 Action in progress: ${currentAction ?? 'idle'}`,
+    `AP: ${perPlayer((id) => PlayersSelector.getNumActionTokens(G.players, id))}`,
+    `VP: ${perPlayer((id) => ScoreBoardSelector.getPlayerPoints(G.table.scoreBoard, id))}`,
+    `工人 Workers: ${perPlayer((id) => PlayersSelector.getNumWorkerTokens(G.players, id))}`,
+    `加班 Overtime: ${perPlayer((id) => PlayersSelector.getNumOvertimeTokens(G.players, id))}`,
+    `行動格 Action slots used: ${occupiedSlots.join(', ') || 'none'}`,
+    `Match: ${matchID} · seat ${playerID ?? 'observer'}`,
+    `UA: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
+  ].join('\n');
+}
+
+export function buildIssueUrl(description: string, snapshot: string): string {
+  const firstLine = description.trim().split('\n')[0];
+  const title = `[bug] ${firstLine || '遊戲問題回報'}`;
+  const body = [
+    '## 問題描述 Description',
+    description.trim() || '(描述問題…)',
+    '',
+    '## 遊戲狀態 Game state',
+    '```',
+    snapshot,
+    '```',
+    '',
+    '> 📸 請將截圖直接貼上（Ctrl/Cmd+V）到這裡 · Paste your screenshots here.',
+  ].join('\n');
+  const params = new URLSearchParams({ title, body, labels: 'bug' });
+  return `${ISSUES_NEW_URL}?${params.toString()}`;
+}
+
+/**
+ * In-game bug report (design: GpBugDialog): auto state snapshot + prefilled
+ * GitHub issue + best-effort board-screenshot-to-clipboard. Minimizable to a
+ * floating 🐞 chip so the player can inspect the board and take their own
+ * screenshots mid-report; the draft survives minimize/restore.
+ */
+export default function BugReportDialog({
+  gameContext,
+  state,
+  onMinimize,
+  onRestore,
+  onClose,
+}: {
+  gameContext: GameContext;
+  state: Exclude<BugReportState, 'closed'>;
+  onMinimize: () => void;
+  onRestore: () => void;
+  onClose: () => void;
+}) {
+  const currentAction = useAppSelector(getCurrentAction);
+  const [description, setDescription] = React.useState('');
+  const [screenshotStatus, setScreenshotStatus] = React.useState<ScreenshotStatus>('idle');
+  const snapshot = buildStateSnapshot(gameContext, currentAction);
+  const issueUrl = buildIssueUrl(description, snapshot);
+
+  const handleCopyScreenshot = async () => {
+    setScreenshotStatus('copying');
+    try {
+      // Hide the report UI itself from the capture.
+      const blob = await toBlob(document.body, {
+        filter: (node) =>
+          !(node instanceof HTMLElement && node.dataset && 'bugReportUi' in node.dataset),
+        pixelRatio: 1,
+      });
+      if (!blob || typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) {
+        throw new Error('clipboard image unsupported');
+      }
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      setScreenshotStatus('copied');
+    } catch {
+      setScreenshotStatus('manual');
+    }
+  };
+
+  // Portaled to <body>: the header that opens this dialog is a sticky
+  // stacking context, which would otherwise confine the fixed overlay.
+  if (state === 'minimized') {
+    return createPortal(
+      <button
+        type="button"
+        data-bug-report-ui=""
+        data-testid="bug-report-chip"
+        className="btn-sticker sm"
+        onClick={onRestore}
+        style={{ position: 'fixed', right: 16, bottom: 16, zIndex: 1500, background: 'var(--orange)' }}
+        title="回到問題回報 · Resume bug report"
+      >
+        🐞 回報中…{' '}
+        <span className="tag-en" style={{ color: 'rgba(255,255,255,0.85)' }}>
+          Resume
+        </span>
+      </button>,
+      document.body,
+    );
+  }
+
+  return createPortal(
+    <div
+      data-bug-report-ui=""
+      data-testid="bug-report-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label="回報問題"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1500,
+        background: 'rgba(42, 36, 34, 0.4)',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 20,
+      }}
+      onClick={onMinimize}
+    >
+      <div
+        style={{
+          background: 'var(--paper)',
+          border: '2px solid var(--ink)',
+          borderRadius: 22,
+          boxShadow: 'var(--shadow-sticker)',
+          width: 'min(560px, 100%)',
+          maxHeight: '88vh',
+          overflowY: 'auto',
+          padding: 22,
+          fontFamily: 'var(--font-zh)',
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span
+            aria-hidden
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 12,
+              background: 'var(--orange)',
+              border: '2px solid var(--ink)',
+              display: 'grid',
+              placeItems: 'center',
+              fontSize: 20,
+              color: 'white',
+            }}
+          >
+            🐞
+          </span>
+          <div>
+            <strong style={{ fontSize: 17, color: 'var(--ink)' }}>回報問題</strong>
+            <div className="en-cap">Report a bug</div>
+          </div>
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              className="icon-btn"
+              data-testid="bug-report-minimize"
+              onClick={onMinimize}
+              title="縮小視窗，先看盤面或自行截圖 · Minimize to inspect the board"
+              aria-label="縮小 · Minimize"
+            >
+              ▁
+            </button>
+            <button
+              type="button"
+              className="icon-btn"
+              data-testid="bug-report-close"
+              onClick={onClose}
+              aria-label="關閉 · Close"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 13, marginBottom: 4 }}>
+              發生了什麼事？ <span className="tag-en">What happened</span>
+            </div>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              data-testid="bug-report-description"
+              placeholder="例：我按了確認招募，但畫面沒有任何反應…"
+              style={{
+                width: '100%',
+                minHeight: 80,
+                border: '2px solid var(--ink)',
+                borderRadius: 12,
+                padding: 10,
+                font: 'inherit',
+                fontSize: 13,
+                resize: 'vertical',
+                background: 'white',
+              }}
+            />
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              gap: 10,
+              alignItems: 'center',
+              background: 'white',
+              border: '1.5px dashed var(--ink-mute)',
+              borderRadius: 12,
+              padding: '10px 12px',
+            }}
+          >
+            <StickerButton
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleCopyScreenshot()}
+              disabled={screenshotStatus === 'copying'}
+              data-testid="bug-report-screenshot"
+            >
+              📸 {screenshotStatus === 'copying' ? '擷取中…' : '複製盤面截圖'}
+            </StickerButton>
+            <div
+              style={{ fontSize: 12, color: 'var(--ink-soft)', lineHeight: 1.5, minWidth: 0 }}
+              data-testid="bug-report-screenshot-status"
+              role="status"
+            >
+              {screenshotStatus === 'copied' &&
+                '✅ 截圖已複製 — 開好 issue 後直接貼上（Ctrl/Cmd+V）。 · Screenshot copied; paste it into the issue.'}
+              {screenshotStatus === 'manual' &&
+                '無法自動複製 — 請先縮小此視窗，再用系統截圖工具（macOS ⌘⇧4 / Windows Win⇧S）自行擷取。 · Auto-copy unavailable; minimize and take a screenshot manually.'}
+              {(screenshotStatus === 'idle' || screenshotStatus === 'copying') &&
+                '也可以先縮小此視窗自行截圖，多張也沒問題。 · You can minimize this dialog and take your own screenshots.'}
+            </div>
+          </div>
+
+          <div>
+            <div style={{ fontWeight: 700, fontSize: 13, marginBottom: 4 }}>
+              遊戲狀態快照 <span className="tag-en">State snapshot（自動附在 issue）</span>
+            </div>
+            <pre
+              data-testid="bug-report-snapshot"
+              style={{
+                background: 'white',
+                border: '1.5px solid var(--paper-3)',
+                borderRadius: 12,
+                padding: 10,
+                fontSize: 11,
+                lineHeight: 1.5,
+                whiteSpace: 'pre-wrap',
+                fontFamily: 'var(--font-mono)',
+                color: 'var(--ink-soft)',
+                margin: 0,
+              }}
+            >
+              {snapshot}
+            </pre>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <StickerButton variant="ghost" size="sm" onClick={onClose}>
+              取消 <span className="tag-en">Cancel</span>
+            </StickerButton>
+            <a
+              className="btn-sticker sm dark"
+              href={issueUrl}
+              target="_blank"
+              rel="noreferrer"
+              data-testid="bug-report-open-issue"
+            >
+              在 GitHub 開 Issue ↗
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/webapp/src/components/board/GameHeader.tsx
+++ b/packages/webapp/src/components/board/GameHeader.tsx
@@ -5,6 +5,7 @@ import { GameContext } from '@/components/GameContextHelpers';
 import { PlayersSelector } from '@/game/store/slice/players';
 import { ScoreBoardSelector } from '@/game/store/slice/scoreBoard';
 import { getPlayerName } from '@/components/playerNameMap';
+import BugReportDialog, { BugReportState } from './BugReportDialog';
 import ExitDialog from './ExitDialog';
 import RoundBadge from './RoundBadge';
 
@@ -27,6 +28,12 @@ export default function GameHeader({
   const { G, ctx, playerID, matchData, matchID } = gameContext;
   const [exitOpen, setExitOpen] = React.useState(false);
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [bugReportState, setBugReportState] = React.useState<BugReportState>('closed');
+
+  const openBugReport = () => {
+    setMenuOpen(false);
+    setBugReportState('open');
+  };
 
   // Mobile shows only your own chip; observers keep the full row.
   const chipIDs =
@@ -125,6 +132,9 @@ export default function GameHeader({
                         ⓘ {hintsOn ? '隱藏操作提示' : '顯示操作提示'}
                       </button>
                     )}
+                    <button type="button" role="menuitem" className="menu-item" data-testid="menu-bug-report" onClick={openBugReport}>
+                      🐞 回報問題 <span className="tag-en">Report</span>
+                    </button>
                     <button type="button" role="menuitem" className="menu-item" data-testid="menu-leave" onClick={openExit}>
                       🚪 離開遊戲 <span className="tag-en">Leave</span>
                     </button>
@@ -149,6 +159,16 @@ export default function GameHeader({
               )}
               <button
                 type="button"
+                className="icon-btn"
+                data-testid="bug-report-open"
+                onClick={openBugReport}
+                title="回報問題 · Report a bug"
+                aria-label="回報問題 · Report a bug"
+              >
+                🐞
+              </button>
+              <button
+                type="button"
                 className="btn-sticker sm ghost"
                 data-testid="header-leave"
                 onClick={openExit}
@@ -160,6 +180,16 @@ export default function GameHeader({
           {/* Mounted lazily: ExitDialog uses the app router, which only exists
               once the user can actually open it. */}
           {exitOpen && <ExitDialog open onClose={() => setExitOpen(false)} matchID={matchID} />}
+          {/* Stays mounted while minimized so the report draft survives. */}
+          {bugReportState !== 'closed' && (
+            <BugReportDialog
+              gameContext={gameContext}
+              state={bugReportState}
+              onMinimize={() => setBugReportState('minimized')}
+              onRestore={() => setBugReportState('open')}
+              onClose={() => setBugReportState('closed')}
+            />
+          )}
         </>
       }
     />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       boardgame.io:
         specifier: ^0.50.2
         version: 0.50.2(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       next:
         specifier: 14.2.3
         version: 14.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4362,6 +4365,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -12588,6 +12594,8 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Adds the prototype's in-game 🐞 bug report: a minimizable dialog that captures an automatic game-state snapshot, tries to copy a board screenshot to the clipboard, and opens a prefilled GitHub issue (`labels=bug`) with paste-your-screenshot guidance — closing the alpha feedback loop without asking players to reconstruct game state by hand.

## Changes

- **BugReportDialog** (`board/BugReportDialog.tsx`, design GpBugDialog, bespoke non-MUI so minimize works): description textarea; auto snapshot (round/total, current player, action in progress, per-player AP·VP·workers·overtime tokens, occupied action slots, match + seat, UA) rendered in the dialog and embedded fenced in the issue body; 在 GitHub 開 Issue ↗ prefilled via URL params (title from the first description line, `labels=bug`, paste-screenshot guidance).
- **Screenshot to clipboard**: `html-to-image` `toBlob` on the board (report UI excluded via a data-attribute filter) → `ClipboardItem` write; on success 截圖已複製…貼上; on any failure (unsupported clipboard, canvas issues) explicit manual-screenshot guidance (⌘⇧4 / Win⇧S). Secure-context only — production https and localhost both qualify.
- **Minimize**: collapses to a floating 🐞 回報中… chip; the component stays mounted so the draft and screenshot status survive; the board is fully interactive meanwhile (players can take their own screenshots, multiple if needed); tap restores. Backdrop click minimizes rather than discarding.
- **Entry points**: desktop header 🐞 icon; mobile ⋯ menu 回報問題 entry.

## Evidence

- [x] Evidence provided
- [ ] Evidence not applicable

**N/A reason:** <!-- Required when "Evidence not applicable" is selected. -->

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| Dialog shows the live state snapshot and prefilled issue link | Dev harness: open 🐞, check snapshot + link | ![dialog](https://raw.githubusercontent.com/ocftw/open-star-ter-village/79e6e6ae0d11b445b8d975fed1df13e3763f31e0/evidence/1-bug-report-dialog.png) |
| Minimized chip keeps the board interactive with the draft preserved | Minimize → idle board + floating chip → restore | ![minimized](https://raw.githubusercontent.com/ocftw/open-star-ter-village/79e6e6ae0d11b445b8d975fed1df13e3763f31e0/evidence/2-bug-report-minimized.png) |
| Snapshot fields, URL encoding (title/labels/body), empty-title fallback | `BugReportDialog.test.tsx` (3 unit tests on the builders) | Jest 146/146 pass |
| Minimize/restore draft survival; clipboard success + manual fallback | `BugReportDialog.test.tsx` (4 component tests, html-to-image + clipboard mocked) | Jest 146/146 pass |
| End-to-end: open → snapshot content → draft → prefilled href → minimize keeps board idle-interactive → restore → close | `game-flow.spec.ts` Scenario 9b | Playwright 31/31 pass |

## Risks and limitations

- Stacked on #426 → #425 → #424 → #423; retargets to `main` as the stack merges. Full gate run locally.
- GitHub's issue form requires the reporter to be signed in; the prefilled URL degrades to GitHub's login flow otherwise.
- `html-to-image` capture of CJK webfonts can be imperfect in some browsers; the manual-screenshot path is the guaranteed fallback and the copy explicitly guides it.
- Screenshot auto-copy needs `ClipboardItem` (Chromium/Safari; Firefox behind a flag) — detected at runtime with the same fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
