### PR TITLE
feat(skills): add project workflow skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,19 @@ You are an **executor agent**. You receive a **task** from the Supervisor (Claud
 Project-owned skills live with the project they operate on. From the repository
 root, use:
 
+- Open Star delivery:
+  `skills/open-star-delivery/SKILL.md`
+- Open Star feedback triage:
+  `skills/open-star-feedback-triage/SKILL.md`
+- Webapp incident response:
+  `packages/webapp/skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test:
   `packages/webapp/skills/webapp-deploy-smoke-test/SKILL.md`
 
 From `packages/webapp/`, use:
 
+- Webapp incident response:
+  `skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test:
   `skills/webapp-deploy-smoke-test/SKILL.md`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,18 @@ human and Copilot review conversation before merge.
 Project-owned skills live with the project they operate on. From the repository
 root, use:
 
+- Open Star delivery:
+  `skills/open-star-delivery/SKILL.md`
+- Open Star feedback triage:
+  `skills/open-star-feedback-triage/SKILL.md`
+- Webapp incident response:
+  `packages/webapp/skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test:
   `packages/webapp/skills/webapp-deploy-smoke-test/SKILL.md`
 
 From `packages/webapp/`, use:
 
+- Webapp incident response:
+  `skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test:
   `skills/webapp-deploy-smoke-test/SKILL.md`

--- a/packages/webapp/AGENTS.md
+++ b/packages/webapp/AGENTS.md
@@ -5,4 +5,5 @@ requirements.
 
 ## Agent Skills
 
+- Webapp incident response: `skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test: `skills/webapp-deploy-smoke-test/SKILL.md`

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -5,4 +5,5 @@ requirements.
 
 ## Agent Skills
 
+- Webapp incident response: `skills/webapp-incident-response/SKILL.md`
 - Webapp deploy smoke test: `skills/webapp-deploy-smoke-test/SKILL.md`

--- a/packages/webapp/skills/webapp-incident-response/SKILL.md
+++ b/packages/webapp/skills/webapp-incident-response/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: webapp-incident-response
+description: Stabilize, investigate, recover, and document Open StarTer Village webapp production incidents involving Fly.io deployment failures, outages, connection errors, unhealthy probes, high CPU or memory, OOM events, WebSocket failures, Sentry errors, or missed UptimeRobot alerts. Use when production is degraded or the user asks to roll back, inspect logs and metrics, diagnose a bad deployment, restore service, or coordinate incident follow-up.
+---
+
+# Webapp Incident Response
+
+Restore user-facing service first, preserve evidence, and separate immediate
+mitigation from the durable fix.
+
+## Set the incident boundary
+
+Record:
+
+- start time and timezone;
+- affected production URLs and surfaces;
+- observed symptoms and reporter evidence;
+- current and previous deployed revisions;
+- latest deployment or configuration change;
+- known user impact; and
+- who is coordinating the incident.
+
+Use `Investigating`, `Mitigating`, `Monitoring`, or `Resolved` consistently.
+State uncertainty plainly.
+
+## Protect production
+
+- Begin with read-only inspection.
+- Ask for explicit authorization before rollback, restart, scaling, secret
+  changes, monitor changes, destructive testing, or any other production
+  mutation not already requested.
+- Prefer rolling back the deployment revision over reverting source history when
+  the immediate goal is service restoration.
+- Do not expose tokens, webhook URLs, headers, environment values, user data, or
+  other secrets in commands or reports.
+- Preserve timestamps, deployment IDs, and relevant log excerpts before changing
+  state.
+
+## Establish independent symptoms
+
+Check from outside Fly.io:
+
+- frontend page availability and response;
+- game server health and lobby REST response;
+- WebSocket or multiplayer connectivity when relevant;
+- UptimeRobot monitor state and alert delivery; and
+- whether impact is global or limited by route, region, client, or role.
+
+Use `../webapp-deploy-smoke-test/SKILL.md` for the full public probe and
+multiplayer procedure. A green provider dashboard does not override a failing
+external probe.
+
+## Correlate the failure
+
+Build a short timestamped timeline from:
+
+- GitHub deployment workflow and merged revision;
+- Fly.io release, machine, allocation, restart, CPU, memory, and OOM state;
+- application and proxy logs;
+- Sentry events when configured;
+- UptimeRobot checks and notification history; and
+- configuration or secret changes.
+
+Compare the incident window with a healthy window. Distinguish evidence from
+inference, and do not assume the latest merge caused the incident merely because
+it preceded it.
+
+## Mitigate
+
+Choose the smallest reversible action that restores service:
+
+1. roll back to the last known healthy deployment;
+2. correct a confirmed configuration error;
+3. restart or scale only when evidence supports it and the user authorizes it;
+4. disable a failing integration or feature when a safe switch exists; or
+5. apply a minimal hotfix when rollback cannot restore service.
+
+After every action, rerun the failed external probes and record the exact result.
+Stop compounding changes when the symptom is not improving.
+
+## Diagnose the cause
+
+Once service is stable:
+
+1. Reproduce the failure safely outside production when possible.
+2. Compare the bad and healthy revisions, runtime configuration, and resource
+   behavior.
+3. Search upstream provider and dependency documentation only for symptoms
+   supported by local evidence.
+4. Test competing explanations and identify the evidence that rejects each one.
+5. Classify the result as confirmed root cause, contributing factor, or remaining
+   hypothesis.
+
+Do not call a resource increase a root-cause fix unless the workload is expected
+and the capacity requirement is demonstrated.
+
+## Deliver the durable fix
+
+- Create or update a GitHub incident issue with impact, timeline, evidence,
+  mitigation, cause, and follow-up actions.
+- Separate the emergency mitigation from durable code, monitoring, and process
+  work.
+- Use the repository pull request and evidence requirements for every code or
+  configuration change.
+- Use `../../../../skills/open-star-delivery/SKILL.md` when the user asks to carry
+  the fix through merge and deployment.
+- Verify the recovered deployment with
+  `../webapp-deploy-smoke-test/SKILL.md`.
+
+## Resolve
+
+Mark the incident resolved only when:
+
+- affected public probes and workflows pass;
+- the deployed revision is known;
+- monitoring remains healthy for an appropriate observation window;
+- alerting behavior is verified or its gap is tracked;
+- user impact and limitations are documented; and
+- every follow-up has an owner or linked issue.
+
+Report the final state as: impact, duration, mitigation, deployed revision,
+confirmed cause or remaining hypothesis, verification, monitoring gaps, and
+follow-up links.

--- a/packages/webapp/skills/webapp-incident-response/agents/openai.yaml
+++ b/packages/webapp/skills/webapp-incident-response/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Webapp Incident Response"
+  short_description: "Stabilize and investigate webapp incidents"
+  default_prompt: "Use $webapp-incident-response to stabilize this production incident, collect evidence, and coordinate recovery."

--- a/skills/open-star-delivery/SKILL.md
+++ b/skills/open-star-delivery/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: open-star-delivery
+description: Deliver an Open StarTer Village GitHub issue, plan, branch, or pull request through implementation, durable evidence, validated review, CI, merge, deployment verification, issue updates, and worktree cleanup. Use when the user asks to deliver, finish, ship, merge and deploy, babysit, or follow an Open StarTer change through to a stated terminal condition.
+---
+
+# Open Star Delivery
+
+Take ownership of the requested delivery outcome while preserving the user's
+authority over production and forge mutations.
+
+## Establish the delivery contract
+
+1. Resolve the issue, plan, branch, or pull request and read all linked work.
+2. Read `AGENTS.md`, the relevant project README, `CONTRIBUTING.md`, and
+   `.github/pull_request_template.md`.
+3. State the requested terminal condition:
+   - implementation complete;
+   - pull request ready;
+   - merged;
+   - deployed and smoke-tested; or
+   - related issues closed and worktree removed.
+4. Do not extend the terminal condition. In particular, do not merge or deploy
+   unless the user's request includes that outcome.
+5. Record the affected project, acceptance criteria, current branch or pull
+   request head, dependencies, and known blockers.
+
+## Prepare isolated work
+
+- Reuse the task's existing worktree when it is clean and correctly scoped.
+- Otherwise create a project worktree and branch before editing. Do not create a
+  nested worktree.
+- Fetch the latest remote state and rebase or merge the intended base according
+  to the repository's current convention.
+- Inspect the worktree before editing and preserve unrelated user changes.
+- Keep commits small, focused, and compliant with the repository convention.
+
+## Complete the implementation
+
+1. Compare the current implementation with every acceptance criterion and linked
+   review comment.
+2. Implement only the missing behavior.
+3. Add or update automated coverage for the changed behavior.
+4. Run the validation required by the nearest `AGENTS.md`.
+5. Simplify redundant code without trading away readability.
+6. Report any criterion that remains deferred, untested, or blocked.
+
+## Build durable evidence
+
+- Map every material claim and changed surface to a real exercised scenario.
+- Collect the evidence required by `CONTRIBUTING.md`; never infer evidence from
+  source code or an unexecuted command.
+- Use durable GitHub-hosted or repository-hosted artifacts. Do not use a local
+  path, localhost URL, expiring artifact, or temporary preview as the only proof.
+- Keep the pull request evidence table synchronized after scope or behavior
+  changes.
+- Open or keep the pull request as draft until evidence and required CI are
+  complete.
+
+## Review and converge
+
+1. Review the complete diff with independent correctness and simplification
+   lenses.
+2. Treat findings as hypotheses. Reproduce defects, search all callers, or run
+   focused experiments before presenting them as valid.
+3. Give each valid finding the smallest fix and a concrete test method.
+4. Apply only the fixes authorized by the user or required by the requested
+   delivery outcome.
+5. Re-run affected checks, update evidence, push, and re-request Copilot review
+   after material changes.
+6. Resolve every human and Copilot conversation before merge.
+7. Re-review the delta after new commits rather than repeating stale findings.
+
+## Merge safely
+
+Before merging, confirm all of the following against the latest head:
+
+- acceptance criteria are complete or explicitly deferred;
+- required CI is green;
+- durable evidence is complete;
+- the pull request is ready, mergeable, and based on the intended base;
+- review conversations are resolved; and
+- risks and limitations are disclosed.
+
+Do not bypass protections, dismiss unresolved review, or claim a queued merge
+has completed. Use the repository's preferred merge strategy and verify the
+resulting merge commit.
+
+## Verify deployment
+
+If deployment is part of the delivery contract:
+
+1. Identify the deployment created from the merged revision.
+2. Monitor the actual workflow and provider state to a terminal result.
+3. For webapp changes, use
+   `../../packages/webapp/skills/webapp-deploy-smoke-test/SKILL.md`.
+4. For homepage changes, run the current homepage production checks documented
+   by that project.
+5. Record the deployed revision, environment, timestamp, checks performed, and
+   any untested limitation.
+6. If production is unhealthy, stop the delivery flow and use
+   `../../packages/webapp/skills/webapp-incident-response/SKILL.md` when
+   applicable.
+
+A merge is not proof of deployment, and a successful deployment job is not
+proof that the user-facing behavior works.
+
+## Close the loop
+
+- Update the parent issue and affected sub-issues with the pull request,
+  deployed revision, evidence, deferred work, and final status.
+- Close an issue only when its acceptance criteria are satisfied at the
+  requested terminal condition.
+- Remove the task worktree and branch only after the work is merged and no
+  uncommitted work remains.
+- Finish with a compact report of implementation, evidence, CI, review, merge,
+  deployment, issue state, cleanup, and remaining risks.

--- a/skills/open-star-delivery/agents/openai.yaml
+++ b/skills/open-star-delivery/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Open Star Delivery"
+  short_description: "Deliver issues through merge and deployment"
+  default_prompt: "Use $open-star-delivery to take this issue or pull request through evidence, review, merge, deployment, and cleanup."

--- a/skills/open-star-feedback-triage/SKILL.md
+++ b/skills/open-star-feedback-triage/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: open-star-feedback-triage
+description: Convert Open StarTer Village playtest feedback, screenshots, bug reports, and UX observations into deduplicated GitHub tracking items with stable identifiers, reproducible evidence, parent-thread indexing, sub-issues, and lifecycle updates. Use when the user submits gameplay feedback or asks to organize, classify, move, update, minimize, or close feedback in a project issue.
+---
+
+# Open Star Feedback Triage
+
+Maintain a trustworthy project feedback ledger without prematurely turning every
+observation into an implementation decision.
+
+## Inspect the tracker first
+
+1. Resolve the parent feedback issue and read its body, comments, linked
+   sub-issues, pull requests, and current identifier scheme.
+2. Search open and closed issues and merged pull requests for the same behavior.
+3. Preserve existing identifiers and numbering. Never reuse or silently
+   renumber an identifier.
+4. Determine whether the parent distinguishes categories such as:
+   - `B`: reproducible bug or incorrect game behavior;
+   - `F`: usability, presentation, or product feedback.
+5. Follow the parent tracker when its convention differs.
+
+## Normalize each report
+
+Inspect every supplied screenshot or recording and retain the reporter's
+original meaning. Record:
+
+- stable identifier and concise title;
+- category and verification state;
+- observed behavior;
+- expected behavior or user need;
+- reproduction steps, game mode, role, turn or phase, device, and viewport when
+  known;
+- visible evidence and its source;
+- user impact and frequency;
+- suspected duplicate or related item; and
+- missing information needed to verify it.
+
+Do not invent details hidden by a screenshot. Mark the report `Unverified` when
+the behavior has not been reproduced or confirmed from code and evidence.
+
+## Classify without overcommitting
+
+Use one of these outcomes:
+
+- **Duplicate**: link the canonical item and add genuinely new evidence there.
+- **Needs clarification**: keep it in the parent tracker with a focused question.
+- **Tracked feedback**: keep a bounded UX or product observation in the parent.
+- **Sub-issue**: promote independently actionable work with its own acceptance
+  criteria, owner, or implementation lifecycle.
+- **Resolved**: link the merged fix and verification evidence.
+- **Deferred or out of scope**: record the reason and any reconsideration trigger.
+
+A proposed solution from the report is context, not a requirement. Separate the
+underlying problem from implementation suggestions.
+
+## Maintain GitHub state
+
+When the user has asked to update the tracker:
+
+1. Add or update the canonical parent comment for the item.
+2. Create a sub-issue only after deduplication and classification.
+3. Link the child to the parent using GitHub's sub-issue relationship when
+   available; otherwise maintain an explicit link in both places.
+4. Keep a parent index with identifier, title, classification, status, and
+   canonical link.
+5. Edit the canonical item instead of posting a chain of corrective comments.
+6. Preserve screenshot links and credit; never expose unrelated private content
+   visible elsewhere in an image.
+
+If the user only asks for analysis, draft the proposed GitHub changes and stop
+before mutating external state.
+
+## Define actionable sub-issues
+
+Each child issue should contain:
+
+- problem statement;
+- observed and expected behavior;
+- reproduction context and evidence;
+- acceptance criteria stated as observable outcomes;
+- relevant dependencies or related items; and
+- known limitations or open questions.
+
+Avoid prescribing architecture unless the feedback itself requires a durable
+design decision.
+
+## Resolve and archive cleanly
+
+Before marking an item resolved:
+
+1. Verify that the linked pull request actually addresses its acceptance
+   criteria.
+2. Record whether the fix is merged, deployed, and playtest-verified; do not
+   collapse these states into one.
+3. Update the parent index and canonical item.
+4. Minimize stale parent comments only after their content is represented by the
+   canonical issue or resolved record.
+5. Close child issues only when the project's chosen completion state has been
+   reached.
+
+End each triage pass with counts for new, duplicate, clarified, promoted,
+resolved, deferred, and still-unverified items.

--- a/skills/open-star-feedback-triage/agents/openai.yaml
+++ b/skills/open-star-feedback-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Open Star Feedback Triage"
+  short_description: "Turn playtest feedback into tracked issues"
+  default_prompt: "Use $open-star-feedback-triage to triage this playtest feedback and maintain its GitHub tracking thread."


### PR DESCRIPTION
<!-- pr-evidence-template:v1 -->

## Summary

Add three project-owned agent skills for delivering changes, triaging playtest
feedback, and responding to webapp incidents. Place each workflow at the
narrowest project level that owns it and expose the skills through the
repository's agent instructions.

## Changes

- Add `open-star-delivery` at the repository level for
  issue-to-merge-and-deployment workflows.
- Add `open-star-feedback-triage` at the repository level for playtest feedback,
  stable identifiers, sub-issues, and lifecycle tracking.
- Add `webapp-incident-response` beside the existing webapp deployment
  smoke-test skill.
- Add Codex UI metadata for all three skills.
- Register the skills in the root and webapp `AGENTS.md` and `CLAUDE.md` files.

## Evidence

- [x] Evidence provided

| Changed surface or material claim | Scenario exercised | Evidence |
| --- | --- | --- |
| All three skill packages have valid frontmatter, names, descriptions, and generated UI metadata | Ran the skill creator's `quick_validate.py` against each skill; all three returned `Skill is valid!`. Parsed each `agents/openai.yaml` as YAML. | Repository objects: [`open-star-delivery`](skills/open-star-delivery/SKILL.md), [`open-star-feedback-triage`](skills/open-star-feedback-triage/SKILL.md), and [`webapp-incident-response`](packages/webapp/skills/webapp-incident-response/SKILL.md). |
| Skill Markdown and cross-skill references are structurally sound | Ran `markdownlint-cli2` over the three skill trees with zero errors, ran `git diff --check`, and resolved each referenced skill path from its containing skill directory. | Repository objects: [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md), and package-level [`AGENTS.md`](packages/webapp/AGENTS.md). No runtime UI or production behavior changes exist to demonstrate. |

## Risks and limitations

- Skill instructions may need refinement after real use. Trigger descriptions
  are project-specific and each workflow is located beside the system it owns
  to limit accidental invocation.
- The skills were statically validated but not forward-tested against live
  GitHub or production operations because doing so would create unnecessary
  external mutations.
- No application code, deployment configuration, secrets, or runtime behavior
  changes are included.
